### PR TITLE
Added property to configure use of full git message

### DIFF
--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
@@ -106,6 +106,13 @@ public class GenerateMojo extends AbstractMojo {
 	 */
 	private String issueManagementUrl;
 
+	/**
+	 * If true, the changelog will include the full git message rather that the short git message
+	 *
+	 * @parameter default-value="false"
+	 */
+	private boolean fullGitMessage;
+	
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		getLog().info("Generating changelog in " + outputDirectory.getAbsolutePath()
 				+ " with title " + reportTitle);
@@ -148,16 +155,16 @@ public class GenerateMojo extends AbstractMojo {
 		ArrayList<ChangeLogRenderer> renderers = new ArrayList<ChangeLogRenderer>();
 
 		if (generatePlainTextChangeLog) {
-			renderers.add(new PlainTextRenderer(getLog(), outputDirectory, plainTextChangeLogFilename));
+			renderers.add(new PlainTextRenderer(getLog(), outputDirectory, plainTextChangeLogFilename, fullGitMessage));
 		}
 
 		if (generateSimpleHTMLChangeLog || generateHTMLTableOnlyChangeLog) {
 			MessageConverter messageConverter = getCommitMessageConverter();
 			if (generateSimpleHTMLChangeLog) {
-				renderers.add(new SimpleHtmlRenderer(getLog(), outputDirectory, simpleHTMLChangeLogFilename, messageConverter, false));
+				renderers.add(new SimpleHtmlRenderer(getLog(), outputDirectory, simpleHTMLChangeLogFilename, fullGitMessage, messageConverter, false));
 			}
 			if (generateHTMLTableOnlyChangeLog) {
-				renderers.add(new SimpleHtmlRenderer(getLog(), outputDirectory, htmlTableOnlyChangeLogFilename, messageConverter, true));
+				renderers.add(new SimpleHtmlRenderer(getLog(), outputDirectory, htmlTableOnlyChangeLogFilename, fullGitMessage, messageConverter, true));
 			}
 		}
 

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/PlainTextRenderer.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/PlainTextRenderer.java
@@ -12,9 +12,11 @@ import static com.github.danielflower.mavenplugins.gitlog.renderers.Formatter.NE
 public class PlainTextRenderer extends FileRenderer {
 
 	private boolean previousWasTag = false;
+	private final boolean fullGitMessage;
 
-	public PlainTextRenderer(Log log, File targetFolder, String filename) throws IOException {
+	public PlainTextRenderer(Log log, File targetFolder, String filename, boolean fullGitMessage) throws IOException {
 		super(log, targetFolder, filename);
+		this.fullGitMessage = fullGitMessage;
 	}
 
 	public void renderHeader(String reportTitle) throws IOException {
@@ -35,7 +37,13 @@ public class PlainTextRenderer extends FileRenderer {
 	}
 
 	public void renderCommit(RevCommit commit) throws IOException {
-		writer.write(Formatter.formatDateTime(commit.getCommitTime()) + "    " + commit.getShortMessage());
+		String message = null;
+		if (fullGitMessage){
+			message = commit.getFullMessage();
+		} else {
+			message = commit.getShortMessage();
+		}
+		writer.write(Formatter.formatDateTime(commit.getCommitTime()) + "    " + message);
 		writer.write(" (" + commit.getCommitterIdent().getName() + ")");
 		writer.write(NEW_LINE);
 		previousWasTag = false;

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/SimpleHtmlRenderer.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/SimpleHtmlRenderer.java
@@ -19,11 +19,13 @@ public class SimpleHtmlRenderer extends FileRenderer {
 	protected StringBuilder tableHtml = new StringBuilder();
 	protected final MessageConverter messageConverter;
 	private final boolean tableOnly;
+	private final boolean fullGitMessage;
 
-	public SimpleHtmlRenderer(Log log, File targetFolder, String filename, MessageConverter messageConverter, boolean tableOnly) throws IOException {
+	public SimpleHtmlRenderer(Log log, File targetFolder, String filename, boolean fullGitMessage, MessageConverter messageConverter, boolean tableOnly) throws IOException {
 		super(log, targetFolder, filename);
 		this.messageConverter = messageConverter;
 		this.tableOnly = tableOnly;
+		this.fullGitMessage = fullGitMessage;
 
 		if (!tableOnly) {
 			InputStream templateStream = getClass().getResourceAsStream("/html/SimpleHtmlTemplate.html");
@@ -34,7 +36,8 @@ public class SimpleHtmlRenderer extends FileRenderer {
 	}
 
 	protected static String htmlEncode(String input) {
-		return StringEscapeUtils.escapeHtml4(input);
+		input = StringEscapeUtils.escapeHtml4(input);
+		return input.replaceAll("\n", "<br/>");
 	}
 
 	@Override
@@ -57,7 +60,12 @@ public class SimpleHtmlRenderer extends FileRenderer {
 	@Override
 	public void renderCommit(RevCommit commit) throws IOException {
 		String date = Formatter.formatDateTime(commit.getCommitTime());
-		String message = messageConverter.formatCommitMessage(SimpleHtmlRenderer.htmlEncode(commit.getShortMessage()));
+		String message = null;
+		if (fullGitMessage){
+			message = messageConverter.formatCommitMessage(SimpleHtmlRenderer.htmlEncode(commit.getFullMessage()));
+		} else {
+			message = messageConverter.formatCommitMessage(SimpleHtmlRenderer.htmlEncode(commit.getShortMessage()));	
+		}
 
 		String author = SimpleHtmlRenderer.htmlEncode(commit.getCommitterIdent().getName());
 		String committer = SimpleHtmlRenderer.htmlEncode(commit.getCommitterIdent().getName());

--- a/src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java
@@ -22,7 +22,7 @@ public class GeneratorTest {
 	@Test
 	public void writePlainTextLogToFile() throws Exception {
 		Log log = new SystemStreamLog();
-		ChangeLogRenderer renderer = new PlainTextRenderer(log, new File("target"), "changelog.txt");
+		ChangeLogRenderer renderer = new PlainTextRenderer(log, new File("target"), "changelog.txt", false);
 		generateReport(log, renderer);
 	}
 
@@ -30,7 +30,7 @@ public class GeneratorTest {
 	public void writeSimpleHtmlLogToFile() throws Exception {
 		Log log = new SystemStreamLog();
 		GitHubIssueLinkConverter messageConverter = new GitHubIssueLinkConverter(log, "https://github.com/danielflower/maven-gitlog-plugin/issues/");
-		ChangeLogRenderer renderer = new SimpleHtmlRenderer(log, new File("target"), "changelog.html", messageConverter, false);
+		ChangeLogRenderer renderer = new SimpleHtmlRenderer(log, new File("target"), "changelog.html", false, messageConverter, false);
 		generateReport(log, renderer);
 	}
 
@@ -38,7 +38,7 @@ public class GeneratorTest {
 	public void writeHtmlTableOnlyLogToFile() throws Exception {
 		Log log = new SystemStreamLog();
 		GitHubIssueLinkConverter messageConverter = new GitHubIssueLinkConverter(log, "https://github.com/danielflower/maven-gitlog-plugin/issues/");
-		ChangeLogRenderer renderer = new SimpleHtmlRenderer(log, new File("target"), "changelogtable.html", messageConverter, true);
+		ChangeLogRenderer renderer = new SimpleHtmlRenderer(log, new File("target"), "changelogtable.html", false, messageConverter, true);
 		generateReport(log, renderer);
 	}
 


### PR DESCRIPTION
We are using this plugin to generate release notes.  It works extremely well however we have quite verbose commit messages that link to bug tracking tools.  Using only the short message does not provide us with all the information we require.  I have added a property that defaults to false so that current behaviour remains unchanged.  If set to true the full commit message is used.

This is the first time I've submitted to Github, please let me know if I have missed anything.

Many thanks, James.
