### PR TITLE
Add dynamic loading loading mechanism for CommitFilters.

### DIFF
--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/Defaults.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/Defaults.java
@@ -1,19 +1,32 @@
 package com.github.danielflower.mavenplugins.gitlog;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ServiceLoader;
+
 import com.github.danielflower.mavenplugins.gitlog.filters.CommitFilter;
 import com.github.danielflower.mavenplugins.gitlog.filters.DuplicateCommitMessageFilter;
 import com.github.danielflower.mavenplugins.gitlog.filters.MavenReleasePluginMessageFilter;
 import com.github.danielflower.mavenplugins.gitlog.filters.MergeCommitFilter;
 
-import java.util.Arrays;
-import java.util.List;
-
 class Defaults {
-
-	public static final List<CommitFilter> COMMIT_FILTERS = Arrays.asList(
+	public static final List<CommitFilter> DEFAULT_COMMIT_FILTERS = Arrays.asList(
 			new MavenReleasePluginMessageFilter(),
 			new MergeCommitFilter(),
 			new DuplicateCommitMessageFilter()
 	);
-
+	
+	public static final List<CommitFilter> COMMIT_FILTERS;
+	
+	static {
+		COMMIT_FILTERS = new ArrayList<CommitFilter>();
+		COMMIT_FILTERS.addAll(DEFAULT_COMMIT_FILTERS);
+		
+		Iterator<CommitFilter> it = ServiceLoader.load(CommitFilter.class).iterator();
+		while (it.hasNext()){
+			COMMIT_FILTERS.add(it.next());
+		}
+	}
 }


### PR DESCRIPTION
This PR uses the [SPI mechanism provided by the JRE](http://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html) to load all implementing classes of the CommitFilter interface. This way it is possible to add a dependency to the plugin configuration in order add new filters dynamically. For example, using the following configuration:

```
<plugin>
  <groupId>com.github.danielflower.mavenplugins</groupId>
  <artifactId>maven-gitlog-plugin</artifactId>
  <version>1.5.3-SNAPSHOT</version>
  <configuration>
    <generateSimpleHTMLChangeLog>false</generateSimpleHTMLChangeLog>
    <generatePlainTextChangeLog>true</generatePlainTextChangeLog>
  </configuration>
  <executions>
    <execution>
      <phase>package</phase>
      <goals>
        <goal>generate</goal>
      </goals>
    </execution>
  </executions>
  <dependencies>
    <dependency>
      <groupId>es.e-ucm.ead</groupId>
      <artifactId>gitlog-maven-plugin-ext</artifactId>
      <version>0.0.1-SNAPSHOT</version>
    </dependency>
  </dependencies>
</plugin>
```

loads the CommitFilters of the es.e-ucm.ead:gitlog-maven-plugin-ext maven artifact.
