### PR TITLE
Add escapes for tab "\t", backspace "\b", form feed "\f" and carriage re...

### DIFF
--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/JsonRenderer.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/JsonRenderer.java
@@ -95,6 +95,10 @@ public class JsonRenderer extends FileRenderer {
 		}
 		input = input.replace("\\", "\\\\");
 		input = input.replace("\n", "\\n");
+		input = input.replace("\t", "\\t");
+		input = input.replace("\b", "\\b");
+		input = input.replace("\f", "\\f");
+		input = input.replace("\r", "\\r");
 		input = input.replace("\"", "\\\"");
 		return input;
 	}


### PR DESCRIPTION
...turn "\r", may create invalid JSON that can't be parsed otherwise.

Had a case at work where someone had used TAB character in a commit message, and the resulting JSON could not be parsed by Jquery or built-in browser parser, possibly others as well. Added in the special ASCII whitespace characters that needs to be escaped according to the spec. See also: http://stackoverflow.com/a/19176131/134276