### PR TITLE
Generate clean HTML

### DIFF
--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/SimpleHtmlRenderer.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/SimpleHtmlRenderer.java
@@ -48,7 +48,7 @@ public class SimpleHtmlRenderer extends FileRenderer {
 
 	@Override
 	public void renderTag(RevTag tag) throws IOException {
-		tableHtml.append("\t\t<tr class=\"tag\"><td colspan=3>")
+		tableHtml.append("\t\t<tr class=\"tag\"><td colspan=\"3\">")
 				.append(SimpleHtmlRenderer.htmlEncode(tag.getTagName()))
 				.append("</td></tr>")
 				.append(NEW_LINE);


### PR DESCRIPTION
Currently the generated HTML does not have double-quotes around the colspan value. This breaks a parser that is checking the file before delivering.