### PR TITLE
Bugzilla with config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.danielflower.mavenplugins</groupId>
     <artifactId>gitlog-maven-plugin</artifactId>
-    <version>1.9-SNAPSHOT</version>
+    <version>1.10-SNAPSHOT</version>
 
     <packaging>maven-plugin</packaging>
     <name>Maven Git Log Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,100 +1,93 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.danielflower.mavenplugins</groupId>
-    <artifactId>gitlog-maven-plugin</artifactId>
-    <version>1.10-SNAPSHOT</version>
+	<groupId>com.github.danielflower.mavenplugins</groupId>
+	<artifactId>maven-gitlog-plugin</artifactId>
+	<version>1.9-SNAPSHOT</version>
 
-    <packaging>maven-plugin</packaging>
-    <name>Maven Git Log Plugin</name>
-    <description>Generates a changelog based on commits to a git repository in text and HTML format showing the changes
-        that are included in each version. A possible use of this is to include these changelogs when packaging your
-        maven project so that you have an accurate list of commits that the current package includes.
-    </description>
-    <url>http://github.com/danielflower/maven-gitlog-plugin</url>
+	<packaging>maven-plugin</packaging>
+	<name>Maven Git Log Plugin</name>
+	<description>Generates a changelog based on commits to a git repository in text and HTML format showing the changes
+		that are included in each version. A possible use of this is to include these changelogs when packaging your
+		maven project so that you have an accurate list of commits that the current package includes.
+	</description>
+	<url>http://github.com/danielflower/maven-gitlog-plugin</url>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <github.global.server>github</github.global.server>
         <plugin.goal.prefix>gitlog</plugin.goal.prefix>
     </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-plugin-api</artifactId>
-            <version>2.2.1</version>
-        </dependency>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+			<version>2.2.1</version>
+		</dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.3</version>
         </dependency>
-        <dependency>
-            <groupId>com.madgag</groupId>
-            <artifactId>org.eclipse.jgit</artifactId>
-            <version>2.99.99.2.0-UNOFFICIAL-ROBERTO-RELEASE</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.jcraft</groupId>
-                    <artifactId>jsch</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.0.1</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>1.3</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+		<dependency>
+			<groupId>com.madgag</groupId>
+			<artifactId>org.eclipse.jgit</artifactId>
+			<version>2.99.99.2.0-UNOFFICIAL-ROBERTO-RELEASE</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.jcraft</groupId>
+					<artifactId>jsch</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.0.1</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-core</artifactId>
+			<version>1.3</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.4</version>
-                <configuration>
-                    <goalPrefix>${plugin.goal.prefix}</goalPrefix>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>default-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                        <phase>process-classes</phase>
-                    </execution>
-                    <execution>
-                        <id>generated-helpmojo</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-plugin-plugin</artifactId>
+				<version>3.4</version>
+				<configuration>
+					<goalPrefix>${plugin.goal.prefix}</goalPrefix>
+				</configuration>
+				<executions>
+					<execution>
+						<id>generated-helpmojo</id>
+						<goals>
+							<goal>helpmojo</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+				</configuration>
+			</plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
@@ -125,8 +118,8 @@
                     </dependency>
                 </dependencies>
             </plugin>
-        </plugins>
-    </build>
+		</plugins>
+	</build>
 
 
     <profiles>
@@ -264,40 +257,40 @@
         </plugins>
     </reporting>
 
-    <licenses>
-        <license>
-            <name>Apache 2</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
+	<licenses>
+		<license>
+			<name>Apache 2</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<distribution>repo</distribution>
+			<comments>A business-friendly OSS license</comments>
+		</license>
+	</licenses>
 
-    <scm>
-        <url>git://github.com/danielflower/maven-gitlog-plugin.git</url>
-        <connection>scm:git:git@github.com/danielflower/maven-gitlog-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:/danielflower/maven-gitlog-plugin.git</developerConnection>
-    </scm>
+	<scm>
+		<url>git://github.com/danielflower/maven-gitlog-plugin.git</url>
+		<connection>scm:git:git@github.com/danielflower/maven-gitlog-plugin.git</connection>
+		<developerConnection>scm:git:git@github.com:/danielflower/maven-gitlog-plugin.git</developerConnection>
+	</scm>
 
-    <developers>
-        <developer>
-            <id>danielflower</id>
-            <name>Daniel Flower</name>
-            <url>http://github.com/danielflower/</url>
-            <timezone>8</timezone>
-        </developer>
-    </developers>
+	<developers>
+		<developer>
+			<id>danielflower</id>
+			<name>Daniel Flower</name>
+			<url>http://github.com/danielflower/</url>
+			<timezone>8</timezone>
+		</developer>
+	</developers>
 
-    <inceptionYear>2011</inceptionYear>
+	<inceptionYear>2011</inceptionYear>
 
     <ciManagement>
         <system>travis-ci</system>
         <url>https://travis-ci.org/danielflower/maven-gitlog-plugin</url>
     </ciManagement>
 
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/danielflower/maven-gitlog-plugin/issues</url>
-    </issueManagement>
+	<issueManagement>
+		<system>GitHub</system>
+		<url>https://github.com/danielflower/maven-gitlog-plugin/issues</url>
+	</issueManagement>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,93 +1,100 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.github.danielflower.mavenplugins</groupId>
-	<artifactId>maven-gitlog-plugin</artifactId>
-	<version>1.9-SNAPSHOT</version>
+    <groupId>com.github.danielflower.mavenplugins</groupId>
+    <artifactId>gitlog-maven-plugin</artifactId>
+    <version>1.9-SNAPSHOT</version>
 
-	<packaging>maven-plugin</packaging>
-	<name>Maven Git Log Plugin</name>
-	<description>Generates a changelog based on commits to a git repository in text and HTML format showing the changes
-		that are included in each version. A possible use of this is to include these changelogs when packaging your
-		maven project so that you have an accurate list of commits that the current package includes.
-	</description>
-	<url>http://github.com/danielflower/maven-gitlog-plugin</url>
+    <packaging>maven-plugin</packaging>
+    <name>Maven Git Log Plugin</name>
+    <description>Generates a changelog based on commits to a git repository in text and HTML format showing the changes
+        that are included in each version. A possible use of this is to include these changelogs when packaging your
+        maven project so that you have an accurate list of commits that the current package includes.
+    </description>
+    <url>http://github.com/danielflower/maven-gitlog-plugin</url>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <github.global.server>github</github.global.server>
         <plugin.goal.prefix>gitlog</plugin.goal.prefix>
     </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-plugin-api</artifactId>
-			<version>2.2.1</version>
-		</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>2.2.1</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.3</version>
         </dependency>
-		<dependency>
-			<groupId>com.madgag</groupId>
-			<artifactId>org.eclipse.jgit</artifactId>
-			<version>2.99.99.2.0-UNOFFICIAL-ROBERTO-RELEASE</version>
-			<exclusions>
-				<exclusion>
-					<groupId>com.jcraft</groupId>
-					<artifactId>jsch</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.0.1</version>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.11</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
-			<version>1.3</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>com.madgag</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>2.99.99.2.0-UNOFFICIAL-ROBERTO-RELEASE</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.jcraft</groupId>
+                    <artifactId>jsch</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.4</version>
-				<configuration>
-					<goalPrefix>${plugin.goal.prefix}</goalPrefix>
-				</configuration>
-				<executions>
-					<execution>
-						<id>generated-helpmojo</id>
-						<goals>
-							<goal>helpmojo</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.4</version>
+                <configuration>
+                    <goalPrefix>${plugin.goal.prefix}</goalPrefix>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-descriptor</id>
+                        <goals>
+                            <goal>descriptor</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                    <execution>
+                        <id>generated-helpmojo</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
@@ -118,8 +125,8 @@
                     </dependency>
                 </dependencies>
             </plugin>
-		</plugins>
-	</build>
+        </plugins>
+    </build>
 
 
     <profiles>
@@ -257,40 +264,40 @@
         </plugins>
     </reporting>
 
-	<licenses>
-		<license>
-			<name>Apache 2</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-			<comments>A business-friendly OSS license</comments>
-		</license>
-	</licenses>
+    <licenses>
+        <license>
+            <name>Apache 2</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
 
-	<scm>
-		<url>git://github.com/danielflower/maven-gitlog-plugin.git</url>
-		<connection>scm:git:git@github.com/danielflower/maven-gitlog-plugin.git</connection>
-		<developerConnection>scm:git:git@github.com:/danielflower/maven-gitlog-plugin.git</developerConnection>
-	</scm>
+    <scm>
+        <url>git://github.com/danielflower/maven-gitlog-plugin.git</url>
+        <connection>scm:git:git@github.com/danielflower/maven-gitlog-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:/danielflower/maven-gitlog-plugin.git</developerConnection>
+    </scm>
 
-	<developers>
-		<developer>
-			<id>danielflower</id>
-			<name>Daniel Flower</name>
-			<url>http://github.com/danielflower/</url>
-			<timezone>8</timezone>
-		</developer>
-	</developers>
+    <developers>
+        <developer>
+            <id>danielflower</id>
+            <name>Daniel Flower</name>
+            <url>http://github.com/danielflower/</url>
+            <timezone>8</timezone>
+        </developer>
+    </developers>
 
-	<inceptionYear>2011</inceptionYear>
+    <inceptionYear>2011</inceptionYear>
 
     <ciManagement>
         <system>travis-ci</system>
         <url>https://travis-ci.org/danielflower/maven-gitlog-plugin</url>
     </ciManagement>
 
-	<issueManagement>
-		<system>GitHub</system>
-		<url>https://github.com/danielflower/maven-gitlog-plugin/issues</url>
-	</issueManagement>
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/danielflower/maven-gitlog-plugin/issues</url>
+    </issueManagement>
 
 </project>

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
@@ -123,6 +123,17 @@ public class GenerateMojo extends AbstractMojo {
 	private String issueManagementUrl;
 
 	/**
+         * Regexp pattern to extract the number from the message.
+         *
+         * The default is: "Bug (\\d+)".
+         * Group 1 (the number) is used in links, so "?:" must be used any non relevant group,
+         * ex.:
+	 * (?:Bug|UPDATE|FIX|ADD|NEW|#) ?#?(\d+)
+	 */
+	@Parameter(defaultValue = "Bug (\\d+)")
+	private String bugzillaPattern;
+
+	/**
 	 * Used to set date format in log messages.
 	 */
 	@Parameter(defaultValue = "yyyy-MM-dd HH:mm:ss Z")
@@ -224,7 +235,8 @@ public class GenerateMojo extends AbstractMojo {
 				} else if (system.toLowerCase().contains("github")) {
 					converter = new GitHubIssueLinkConverter(getLog(), issueManagementUrl);
 				} else if (system.toLowerCase().contains("bugzilla")) {
-					converter = new BugzillaIssueLinkConverter(getLog(), issueManagementUrl);
+                                    converter = new BugzillaIssueLinkConverter(getLog(), issueManagementUrl,
+                                        bugzillaPattern);
 				}
 			}
 		} catch (Exception ex) {

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
@@ -121,7 +121,7 @@ public class GenerateMojo extends AbstractMojo {
 	 */
 	@Parameter(property="project.issueManagement.url")
 	private String issueManagementUrl;
-	
+
 	/**
 	 * Used to set date format in log messages.
 	 */
@@ -133,13 +133,13 @@ public class GenerateMojo extends AbstractMojo {
 	 */
 	@Parameter(defaultValue="false")
 	private boolean fullGitMessage;
-	
+
 	/**
 	 * Include in the changelog the commits after this parameter value.
 	 */
 	@Parameter(defaultValue="1970-01-01 00:00:00.0 AM")
 	private Date includeCommitsAfter;
-	
+
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		getLog().info("Generating changelog in " + outputDirectory.getAbsolutePath()
 				+ " with title " + reportTitle);
@@ -174,7 +174,7 @@ public class GenerateMojo extends AbstractMojo {
 		if (!"".equals(dateFormat)) {
 			Formatter.setFormat(dateFormat, getLog());
 		}
-		
+
 		try {
 			generator.generate(reportTitle, includeCommitsAfter);
 		} catch (IOException e) {
@@ -219,10 +219,12 @@ public class GenerateMojo extends AbstractMojo {
 		try {
 			if (issueManagementUrl != null && issueManagementUrl.contains("://")) {
 				String system = ("" + issueManagementSystem).toLowerCase();
-				if (system.contains("jira")) {
+				if (system.toLowerCase().contains("jira")) {
 					converter = new JiraIssueLinkConverter(getLog(), issueManagementUrl);
-				} else if (system.contains("github")) {
+				} else if (system.toLowerCase().contains("github")) {
 					converter = new GitHubIssueLinkConverter(getLog(), issueManagementUrl);
+				} else if (system.toLowerCase().contains("bugzilla")) {
+					converter = new BugzillaIssueLinkConverter(getLog(), issueManagementUrl);
 				}
 			}
 		} catch (Exception ex) {

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/BugzillaIssueLinkConverter.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/BugzillaIssueLinkConverter.java
@@ -1,0 +1,49 @@
+package com.github.danielflower.mavenplugins.gitlog.renderers;
+
+import org.apache.maven.plugin.logging.Log;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * bugzilla link converter
+ * ex.:
+ *
+ * Bug 1123 Some commit message related to Bug 11230
+ * ->
+ * <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1123">Bug 1123</a> Some commit message related
+ * to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=11230">Bug 11230</a>
+                                *
+ * https://bugzilla.mozilla.org/show_bug.cgi?id=<number>
+ *
+ * @author hrotkogabor
+ */
+public class BugzillaIssueLinkConverter implements MessageConverter {
+
+	private Pattern pattern;
+	private final Log log;
+	private final String urlPrefix;
+	private final String urlSufix ="/show_bug.cgi?id=";
+
+	public BugzillaIssueLinkConverter(Log log, String urlPrefix) {
+		this.log = log;
+		// strip off trailing slash
+		urlPrefix = urlPrefix.endsWith("/") ? urlPrefix.substring(0, urlPrefix.length() - 1) : urlPrefix;
+		// strip off jira project code
+		this.urlPrefix = !urlPrefix.endsWith(urlSufix) ? (urlPrefix + urlSufix) : urlPrefix;
+		this.pattern = Pattern.compile("Bug (\\d+)");
+	}
+
+	@Override
+	public String formatCommitMessage(String original) {
+		try {
+			Matcher matcher = pattern.matcher(original);
+				String result = matcher.replaceAll("<a href=\"" + urlPrefix + "$1\">Bug $1</a>");
+				return result;
+		} catch (Exception e) {
+			// log, but don't let this small setback fail the build
+			log.info("Unable to parse issue tracking URL in commit message: " + original, e);
+		}
+		return original;
+	}
+}

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/BugzillaIssueLinkConverter.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/BugzillaIssueLinkConverter.java
@@ -25,13 +25,13 @@ public class BugzillaIssueLinkConverter implements MessageConverter {
 	private final String urlPrefix;
 	private final String urlSufix ="/show_bug.cgi?id=";
 
-	public BugzillaIssueLinkConverter(Log log, String urlPrefix) {
+	public BugzillaIssueLinkConverter(Log log, String urlPrefix, String bugzillaPattern) {
 		this.log = log;
 		// strip off trailing slash
 		urlPrefix = urlPrefix.endsWith("/") ? urlPrefix.substring(0, urlPrefix.length() - 1) : urlPrefix;
 		// strip off jira project code
 		this.urlPrefix = !urlPrefix.endsWith(urlSufix) ? (urlPrefix + urlSufix) : urlPrefix;
-		this.pattern = Pattern.compile("Bug (\\d+)");
+		this.pattern = Pattern.compile(bugzillaPattern, Pattern.CASE_INSENSITIVE);
 	}
 
 	@Override

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -18,7 +18,7 @@ in your target folder:
 	</plugin>
 
 HTML reports will render issue codes as links if you have your issue tracking system is defined in your pom file.
-Currently only Jira and GitHub issue tracking is supported.
+Currently only Jira, GitHub and Bugzilla issue tracking is supported.
 
 	<issueManagement>
 		<system>GitHub</system>
@@ -53,6 +53,7 @@ The following example shows all the possible configuration values with default v
 			<fullGitMessage>true</fullGitMessage>
 			<dateFormat>yyyy-MM-dd HH:mm:ss Z</dateFormat>
 			<includeCommitsAfter>2014-04-01 00:00:00.0 AM</includeCommitsAfter>
+			<bugzillaPattern>(?:Bug|UPDATE|FIX|ADD|NEW|#) ?#?(\d+)</bugzillaPattern>
 		</configuration>
 		<executions>
 			<execution>

--- a/src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/BugzillaIssueLinkConverterTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/BugzillaIssueLinkConverterTest.java
@@ -7,7 +7,9 @@ import org.junit.Test;
 public class BugzillaIssueLinkConverterTest {
 
 	private static final String PREFIX = "https://bugzilla.mozilla.org/show_bug.cgi?id=";
-	private BugzillaIssueLinkConverter converter = new BugzillaIssueLinkConverter(new SystemStreamLog(), PREFIX);
+	private static final String bugzillaPattern = "Bug (\\d+)";
+	private BugzillaIssueLinkConverter converter =
+            new BugzillaIssueLinkConverter(new SystemStreamLog(), PREFIX, bugzillaPattern);
 
 	@Test
 	public void emptyMessagesAreUnchanged() {
@@ -43,8 +45,16 @@ public class BugzillaIssueLinkConverterTest {
 	@Test
 	public void urlWithTrailingSlashHasItRemovedCorrectly() {
 		BugzillaIssueLinkConverter converter = new BugzillaIssueLinkConverter(new SystemStreamLog(),
-				PREFIX+"/");
+				PREFIX+"/", bugzillaPattern);
 		String actual = converter.formatCommitMessage("Bug 1123 Some commit message");
+		assertEquals("<a href=\""+PREFIX+"1123\">Bug 1123</a> Some commit message", actual);
+	}
+
+	@Test
+	public void customPAttern() {
+		BugzillaIssueLinkConverter converter = new BugzillaIssueLinkConverter(new SystemStreamLog(),
+				PREFIX+"/", "(?:Bug|UPDATE) ?#?(\\d+)");
+		String actual = converter.formatCommitMessage("UPDATE #1123 Some commit message");
 		assertEquals("<a href=\""+PREFIX+"1123\">Bug 1123</a> Some commit message", actual);
 	}
 

--- a/src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/BugzillaIssueLinkConverterTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/BugzillaIssueLinkConverterTest.java
@@ -1,0 +1,56 @@
+package com.github.danielflower.mavenplugins.gitlog.renderers;
+
+import static org.junit.Assert.assertEquals;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.junit.Test;
+
+public class BugzillaIssueLinkConverterTest {
+
+	private static final String PREFIX = "https://bugzilla.mozilla.org/show_bug.cgi?id=";
+	private BugzillaIssueLinkConverter converter = new BugzillaIssueLinkConverter(new SystemStreamLog(), PREFIX);
+
+	@Test
+	public void emptyMessagesAreUnchanged() {
+		test("", "");
+	}
+
+	@Test
+	public void noItemReferencesReturnsMessagesAreUnchanged() {
+		String someMessage = "This is some #1 gh-2 conf-3 Bug- message Bugzilla-YO";
+		test(someMessage, someMessage);
+	}
+
+	@Test
+	public void bugzillaCodeAtBeginningIsRendered() {
+		test("Bug 1123 Some commit message", "<a href=\"" + PREFIX + "1123\">Bug 1123</a> Some commit message");
+	}
+
+	@Test
+	public void multipleBugzillaCodesAreRendered() {
+		test("Bug 1123 Some Bug 11239 commit message Bug 11238",
+				"<a href=\"" + PREFIX + "1123\">Bug 1123</a> Some <a href=\"" + PREFIX
+						+ "11239\">Bug 11239</a> commit message " +
+                                "<a href=\"" + PREFIX + "11238\">Bug 11238</a>");
+	}
+
+	@Test
+	public void bugzillaCodesInOtherProjectsAreRendered() {
+		test("Bug 1123 Some commit message related to Bug 11230",
+                     "<a href=\"" + PREFIX + "1123\">Bug 1123</a> Some commit message related to " +
+				"<a href=\""+PREFIX+"11230\">Bug 11230</a>");
+	}
+
+	@Test
+	public void urlWithTrailingSlashHasItRemovedCorrectly() {
+		BugzillaIssueLinkConverter converter = new BugzillaIssueLinkConverter(new SystemStreamLog(),
+				PREFIX+"/");
+		String actual = converter.formatCommitMessage("Bug 1123 Some commit message");
+		assertEquals("<a href=\""+PREFIX+"1123\">Bug 1123</a> Some commit message", actual);
+	}
+
+	private void test(String input, String expectedOutput) {
+		String actual = converter.formatCommitMessage(input);
+		assertEquals("Input: " + input, expectedOutput, actual);
+	}
+
+}


### PR DESCRIPTION
Add a plugin config option to configure the regexp pattern used by bugzilla link converter.

<configuration>
    <bugzillaPattern>(?:Bug|UPDATE|FIX|ADD|NEW|#) ?#?(\d+)</bugzillaPattern>
</configuration>

doc:
Regexp pattern to extract the number from the message.
The default is: "Bug (\\d+)".
Group 1 (the number) is used in links, so "?:" must be used any non relevant group,
ex.:
(?:Bug|UPDATE|FIX|ADD|NEW|#) ?#?(\d+)
