### PR TITLE
Enable to filter commits by a commiter name

### DIFF
--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/CommiterFilter.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/CommiterFilter.java
@@ -1,0 +1,24 @@
+package com.github.danielflower.mavenplugins.gitlog.filters;
+
+import org.eclipse.jgit.revwalk.RevCommit;
+
+import java.util.List;
+
+public class CommiterFilter implements CommitFilter {
+
+	private final List<String> commiters;
+
+	public CommiterFilter(List<String> commiters) {
+		this.commiters = commiters;
+	}
+
+	@Override
+	public boolean renderCommit(RevCommit commit) {
+		for (String commiter : commiters) {
+			if (commiter.equalsIgnoreCase(commit.getCommitterIdent().getName())) {
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -54,6 +54,9 @@ The following example shows all the possible configuration values with default v
 			<dateFormat>yyyy-MM-dd HH:mm:ss Z</dateFormat>
 			<includeCommitsAfter>2014-04-01 00:00:00.0 AM</includeCommitsAfter>
 			<bugzillaPattern>(?:Bug|UPDATE|FIX|ADD|NEW|#) ?#?(\d+)</bugzillaPattern>
+			<excludeCommiters>
+				<commiter>jenkins</commiter>
+			</excludeCommiters>
 		</configuration>
 		<executions>
 			<execution>


### PR DESCRIPTION
Rationale: maven-jgitflow-plugin in contrary to maven-release-plugin does not provide any marker in the commit message. It's not uncommon to have an artificial user handle project building and releasing (i.e. 'jenkins'). With this change, I can easily filter commit messages by the user name.