### PR TITLE
Add path option to filter out commits only related to that path

### DIFF
--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
@@ -2,6 +2,7 @@ package com.github.danielflower.mavenplugins.gitlog;
 
 import com.github.danielflower.mavenplugins.gitlog.filters.CommitFilter;
 import com.github.danielflower.mavenplugins.gitlog.filters.CommiterFilter;
+import com.github.danielflower.mavenplugins.gitlog.filters.PathCommitFilter;
 import com.github.danielflower.mavenplugins.gitlog.filters.RegexpFilter;
 import com.github.danielflower.mavenplugins.gitlog.renderers.*;
 import org.apache.maven.plugin.AbstractMojo;
@@ -10,6 +11,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.jgit.lib.Repository;
 
 import java.io.File;
 import java.io.IOException;
@@ -201,10 +203,11 @@ public class GenerateMojo extends AbstractMojo {
 			commitFilters.add(new RegexpFilter(excludeCommitsPattern));
 		}
 
-		Generator generator = new Generator(renderers, commitFilters, path, getLog());
+		Generator generator = new Generator(renderers, commitFilters, getLog());
+		Repository repository;
 
 		try {
-			generator.openRepository();
+			 repository = generator.openRepository();
 		} catch (IOException e) {
 			getLog().warn("Error opening git repository.  Is this Maven project hosted in a git repository? " +
 					"No changelog will be generated.", e);
@@ -213,6 +216,10 @@ public class GenerateMojo extends AbstractMojo {
 			getLog().warn("This maven project does not appear to be in a git repository, " +
 					"therefore no git changelog will be generated.");
 			return;
+		}
+
+		if (path != null) {
+			commitFilters.add(new PathCommitFilter(repository, path, getLog()));
 		}
 
 		if (!"".equals(dateFormat)) {

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
@@ -168,6 +168,11 @@ public class GenerateMojo extends AbstractMojo {
 	@Parameter
 	private String excludeCommitsPattern;
 
+	/**
+	 * If set only displays commits related to files found under this path.
+	 */
+	@Parameter
+	private String path;
 
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
@@ -196,7 +201,7 @@ public class GenerateMojo extends AbstractMojo {
 			commitFilters.add(new RegexpFilter(excludeCommitsPattern));
 		}
 
-		Generator generator = new Generator(renderers, commitFilters, getLog());
+		Generator generator = new Generator(renderers, commitFilters, path, getLog());
 
 		try {
 			generator.openRepository();

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/PathCommitFilter.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/PathCommitFilter.java
@@ -59,11 +59,11 @@ public class PathCommitFilter implements CommitFilter {
     }
 
     private List<DiffEntry> getDiffs(RevCommit commit, RevCommit parent) throws IOException {
-        DiffFormatter df = new DiffFormatter(DisabledOutputStream.INSTANCE);
-        df.setRepository(repository);
-        df.setDiffComparator(RawTextComparator.DEFAULT);
-        df.setDetectRenames(true);
+        DiffFormatter formatter = new DiffFormatter(DisabledOutputStream.INSTANCE);
+        formatter.setRepository(repository);
+        formatter.setDiffComparator(RawTextComparator.DEFAULT);
+        formatter.setDetectRenames(true);
 
-        return df.scan(parent.getTree(), commit.getTree());
+        return formatter.scan(parent.getTree(), commit.getTree());
     }
 }

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/PathCommitFilter.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/PathCommitFilter.java
@@ -1,0 +1,58 @@
+package com.github.danielflower.mavenplugins.gitlog.filters;
+
+import org.apache.maven.plugin.logging.Log;
+import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.diff.DiffFormatter;
+import org.eclipse.jgit.diff.RawTextComparator;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.util.io.DisabledOutputStream;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Filters out commits not related to files under a given path.
+ *
+ * @author Oliver Weiler (weiler@predic8.de)
+ */
+public class PathCommitFilter implements CommitFilter {
+    private final Repository repository;
+    private final String path;
+    private final Log log;
+
+    public PathCommitFilter(Repository repository, String path, Log log) {
+        this.repository = repository;
+        this.path = path;
+        this.log = log;
+    }
+
+    @Override
+    public boolean renderCommit(RevCommit commit) {
+        try {
+            return isFoundInPath(commit);
+        } catch (IOException e) {
+            log.warn("Error while diffing commits.  Filter won't be applied.", e);
+            return true;
+        }
+    }
+
+    private boolean isFoundInPath(RevCommit commit) throws IOException {
+        for (DiffEntry diff : getDiffs(commit, commit.getParent(0))) {
+            if (diff.getNewPath().startsWith(path)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private List<DiffEntry> getDiffs(RevCommit commit, RevCommit parent) throws IOException {
+        DiffFormatter df = new DiffFormatter(DisabledOutputStream.INSTANCE);
+        df.setRepository(repository);
+        df.setDiffComparator(RawTextComparator.DEFAULT);
+        df.setDetectRenames(true);
+
+        return df.scan(parent.getTree(), commit.getTree());
+    }
+}

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/PathCommitFilter.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/PathCommitFilter.java
@@ -36,10 +36,6 @@ public class PathCommitFilter implements CommitFilter {
 
     @Override
     public boolean renderCommit(RevCommit commit) {
-        if (commit.getParentCount() != 1) {
-            return false;
-        }
-
         try {
             return isFoundInPath(commit);
         } catch (IOException e) {

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/PathCommitFilter.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/PathCommitFilter.java
@@ -8,38 +8,49 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.util.io.DisabledOutputStream;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
 /**
  * Filters out commits not related to files under a given path.
  *
- * @author Oliver Weiler (weiler@predic8.de)
+ * @author helpermethod
  */
 public class PathCommitFilter implements CommitFilter {
     private final Repository repository;
-    private final String path;
+    private final String relativizedPath;
     private final Log log;
 
     public PathCommitFilter(Repository repository, String path, Log log) {
         this.repository = repository;
-        this.path = path;
+        this.relativizedPath = relativizePath(repository, path);
         this.log = log;
+    }
+
+    private String relativizePath(Repository repository, String path) {
+        File p = new File(path);
+
+        return p.isAbsolute() ? repository.getDirectory().getParentFile().toURI().relativize(p.toURI()).getPath() : path;
     }
 
     @Override
     public boolean renderCommit(RevCommit commit) {
+        if (commit.getParentCount() != 1) {
+            return false;
+        }
+
         try {
             return isFoundInPath(commit);
         } catch (IOException e) {
             log.warn("Error while diffing commits.  Filter won't be applied.", e);
-            return true;
+            return false;
         }
     }
 
     private boolean isFoundInPath(RevCommit commit) throws IOException {
         for (DiffEntry diff : getDiffs(commit, commit.getParent(0))) {
-            if (diff.getNewPath().startsWith(path)) {
+            if (diff.getNewPath().startsWith(relativizedPath)) {
                 return true;
             }
         }


### PR DESCRIPTION
The git log command provides a very useful path argument which allows filtering commits based on a path, where only commits are shown related to files under this path.

The `path` parameter makes this functionality available to the maven-gitlog-plugin. If no `path` parameter is specified, no filtering is applied.

If the path parameter is specified, e.g.

    <configuration>
        <path>src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/</path>
    </configuration>

only the commits related to that path are shown.

I've tried implementing this functionality as a filter but couldn't because I need a reference to the git repository to get the differences between the current commit and its parent.