### PR TITLE
Add Asciidoc converter support

### DIFF
--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
@@ -63,10 +63,22 @@ public class GenerateMojo extends AbstractMojo {
 	private boolean generateMarkdownChangeLog;
 
 	/**
+	 * If true, then an Asciidoc changelog will be generated.
+	 */
+	@Parameter(defaultValue = "false")
+	private boolean generatAsciidocChangeLog;
+
+	/**
 	 * The filename of the markdown changelog, if generated.
 	 */
 	@Parameter(defaultValue = "changelog.md")
 	private String markdownChangeLogFilename;
+
+	/**
+	 * The filename of the Asciidoc changelog, if generated.
+	 */
+	@Parameter(defaultValue = "changelog.adoc")
+	private String asciidocChangeLogFilename;
 
 	/**
 	 * If true, then a simple HTML changelog will be generated.
@@ -240,7 +252,7 @@ public class GenerateMojo extends AbstractMojo {
 			renderers.add(new PlainTextRenderer(getLog(), outputDirectory, plainTextChangeLogFilename, fullGitMessage));
 		}
 
-		if (generateSimpleHTMLChangeLog || generateHTMLTableOnlyChangeLog || generateMarkdownChangeLog) {
+		if (generateSimpleHTMLChangeLog || generateHTMLTableOnlyChangeLog || generateMarkdownChangeLog || generatAsciidocChangeLog) {
 			MessageConverter messageConverter = getCommitMessageConverter();
 			if (generateSimpleHTMLChangeLog) {
 				renderers.add(new SimpleHtmlRenderer(getLog(), outputDirectory, simpleHTMLChangeLogFilename, fullGitMessage, messageConverter, false));
@@ -250,6 +262,9 @@ public class GenerateMojo extends AbstractMojo {
 			}
 			if (generateMarkdownChangeLog) {
 				renderers.add(new MarkdownRenderer(getLog(), outputDirectory, markdownChangeLogFilename, fullGitMessage, messageConverter));
+			}
+			if (generatAsciidocChangeLog) {
+				renderers.add(new AsciidocRenderer(getLog(), outputDirectory, asciidocChangeLogFilename, fullGitMessage, messageConverter));
 			}
 		}
 

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/AsciidocLinkConverter.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/AsciidocLinkConverter.java
@@ -1,0 +1,41 @@
+package com.github.danielflower.mavenplugins.gitlog.renderers;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.maven.plugin.logging.Log;
+
+/**
+ * Helper class to convert a HTML link into an Asciidoc link.
+ * 
+ * It searches for a <a href="...URL...">...Text...</a> and the
+ * URL and text is used to build afterwards the Asciidoc link.
+ * The Asciidoc links goes like ...URL...[...Text...].
+ *
+ */
+public class AsciidocLinkConverter {
+
+	private Pattern pattern;
+	private final Log log;
+
+	public AsciidocLinkConverter(Log log) {
+		this.log = log;
+		// see http://stackoverflow.com/questions/26323/regex-to-parse-hyperlinks-and-descriptions
+		// limited to double quotes (removed the single quote),
+		// because the Converters will use double quotes.
+		this.pattern = Pattern.compile("<a\\s+href=(\"([^\"]+)\").*?>(.*?)</a>");
+	}
+	
+	public String formatCommitMessage(String original) {
+		try {
+			Matcher matcher = pattern.matcher(original);
+			String result = matcher.replaceAll("$2[$3]");
+			return result;
+		} catch (Exception e) {
+			// log, but don't let this small setback fail the build
+			log.info("Unable to convert a HTML link into asciidoc link: " + original, e);
+		}
+		return original;
+	}
+	
+}

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/AsciidocRenderer.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/AsciidocRenderer.java
@@ -1,0 +1,84 @@
+package com.github.danielflower.mavenplugins.gitlog.renderers;
+
+import static com.github.danielflower.mavenplugins.gitlog.renderers.Formatter.NEW_LINE;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.maven.plugin.logging.Log;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevTag;
+
+/**
+ * Asciidoc Renderer to get a*.md file.
+ * 
+ * The created asciidoc file will have
+ * - a document title (level 0),
+ * - bold tags 
+ * - and commits in each line.
+ * 
+ * Asciidoc reference is http://asciidoctor.org/docs/
+ *  
+ * Output Example:
+ * 		= Maven GitLog Plugin changelog
+ * 		*maven-gitlog-plugin-1.4.11*
+ * 		2012-03-17 07:33:55 +0100    Updated maven version in docs (Daniel Flower)  
+ * 		...
+ *  
+ */
+public class AsciidocRenderer extends FileRenderer {
+
+	private boolean previousWasTag = false;
+	private final boolean fullGitMessage;
+	protected final MessageConverter messageConverter;
+	private AsciidocLinkConverter asciidocLinkConverter;
+
+	public AsciidocRenderer(Log log, File targetFolder, String filename, boolean fullGitMessage, MessageConverter messageConverter) throws IOException {
+		super(log, targetFolder, filename);
+		this.fullGitMessage = fullGitMessage;
+		this.messageConverter = messageConverter;
+		asciidocLinkConverter = new AsciidocLinkConverter(log);
+	}
+
+	public void renderHeader(String reportTitle) throws IOException {
+		if (reportTitle != null && reportTitle.length() > 0) {
+			writer.write("= "); // MD Heading 1
+			writer.write(reportTitle);
+			writer.write(NEW_LINE);
+			writer.write(NEW_LINE);
+		}
+	}
+
+	public void renderTag(RevTag tag) throws IOException {
+		if (!previousWasTag) {
+			writer.write(NEW_LINE);
+		}
+		writer.write("*"); // MD start bold
+		writer.write(tag.getTagName());
+		writer.write("*"); // MD end bold
+		writer.write(" +"); // MD line warp
+		writer.write(NEW_LINE);
+		previousWasTag = true;
+	}
+
+	public void renderCommit(RevCommit commit) throws IOException {
+		String message = null;
+		// use the message formatter to get a HTML hyperlink
+		if (fullGitMessage){
+			message = messageConverter.formatCommitMessage(commit.getFullMessage());
+		} else {
+			message = messageConverter.formatCommitMessage(commit.getShortMessage());
+		}
+		// now convert the HTML hyperlink into an Asciidoc link
+		message = asciidocLinkConverter.formatCommitMessage(message);
+		writer.write(Formatter.formatDateTime(commit.getCommitTime()) + "    " + message);
+		writer.write(" (" + commit.getCommitterIdent().getName() + ")");
+		writer.write(" +"); // MD line warp
+		writer.write(NEW_LINE);
+		previousWasTag = false;
+	}
+
+
+	public void renderFooter() throws IOException {
+	}
+}

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -12,4 +12,5 @@ Using the default plugin parameters, the changelog for this project looks like t
 
 [HTML example](http://danielflower.github.com/maven-gitlog-plugin/samples/changelog.html) /
 [Markdown example](http://danielflower.github.com/maven-gitlog-plugin/samples/changelog.md) /
+[Asciidoc example](http://danielflower.github.com/maven-gitlog-plugin/samples/changelog.adoc) /
 [Text example](http://danielflower.github.com/maven-gitlog-plugin/samples/changelog.txt)

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -43,6 +43,8 @@ The following example shows all the possible configuration values with default v
 			<generateSimpleHTMLChangeLog>true</generateSimpleHTMLChangeLog>
 			<markdownChangeLogFilename>changelog-${project.version}.md</markdownChangeLogFilename>
 			<generateMarkdownChangeLog>true</generateMarkdownChangeLog>
+			<asciidocChangeLogFilename>changelog-${project.version}.adoc</asciidocChangeLogFilename>
+			<generateAsciidocChangeLog>true</generateAsciidocChangeLog>
 			<simpleHTMLChangeLogFilename>changelog-${project.version}.html</simpleHTMLChangeLogFilename>
 			<generateHTMLTableOnlyChangeLog>true</generateHTMLTableOnlyChangeLog>
 			<htmlTableOnlyChangeLogFilename>changelog-${project.version}-tableonly.html</htmlTableOnlyChangeLogFilename>

--- a/src/site/resources/samples/changelog.adoc
+++ b/src/site/resources/samples/changelog.adoc
@@ -1,0 +1,157 @@
+= Maven GitLog Plugin changelog
+
+
+*gitlog-maven-plugin-1.13.0* +
+*gitlog-maven-plugin-1.13.1* +
+*gitlog-maven-plugin-1.13.2* +
+2016-03-20 14:12:39 +0100    Bumped minor version (Daniel Flower) +
+2016-03-20 14:11:30 +0100    Updated release plugin version (Daniel Flower) +
+
+*gitlog-maven-plugin-1.12.4* +
+2016-03-16 13:26:41 +0100    Remove unnecessay check (Oliver Weiler) +
+2016-03-15 12:03:00 +0100    Update PathCommitFilter.java (Oliver Weiler) +
+2016-03-15 10:25:22 +0100    Add support for specifiying absolute paths (helpermethod) +
+2016-03-15 09:17:43 +0100    Extract path filtering login into PathCommitFilter to introduce as few changes a possible (helpermethod) +
+2016-03-14 13:48:00 +0100    Add path option to filter out commits only related to files found under this path (helpermethod) +
+
+*gitlog-maven-plugin-1.12.1* +
+*gitlog-maven-plugin-1.12.2* +
+*gitlog-maven-plugin-1.12.3* +
+2015-10-26 17:14:57 +0100    Implement filtering commit messages basing on regexp (dziesio) +
+
+*gitlog-maven-plugin-1.12.0* +
+2015-07-20 14:12:30 +0200    add "Gitlog report at site generation" section to the usage (Hrotkó Gábor) +
+2015-07-15 22:23:28 +0200    reporintg without aggregate (hrotkog) +
+
+*gitlog-maven-plugin-1.11.0* +
+2015-07-05 14:13:36 +0200    Upgraded release plugin version (Daniel Flower) +
+2015-07-05 14:07:22 +0200    Fixing merge conflicts (Daniel Flower) +
+2015-06-28 22:28:10 +0200    add note about possible reporting plugin conflict (hrotkog) +
+2015-06-28 22:22:36 +0200    revert default filenames (hrotkog) +
+2015-06-24 14:57:27 +0200    able to test custom git dir (hrotkog) +
+2015-06-24 14:52:22 +0200    can be used as a reporting plugin (hrotkog) +
+2015-06-16 20:25:26 +0200    Change HTML format style (Grzegorz Poznachowski) +
+
+*gitlog-maven-plugin-1.10.1* +
+2015-05-30 18:27:23 +0200    Exclude commiters sample configuration added to site usage file (Grzegorz Poznachowski) +
+2015-05-28 01:25:45 +0200    Enable to filter commits by a commiter name (Grzegorz Poznachowski) +
+
+*gitlog-maven-plugin-1.10.0* +
+2015-03-28 13:58:10 +0100    Fixing javadoc errors (Daniel Flower) +
+2015-03-28 11:09:25 +0100    Updated the release plugin (Daniel Flower) +
+2015-03-28 11:07:35 +0100    Fixed formatting (Daniel Flower) +
+2015-03-24 16:31:48 +0100    Update usage.md.vm (hrotkogabor) +
+2015-03-24 16:14:57 +0100    ability to configure the regexp pattern for bugzilla (hrotkog) +
+2015-03-24 14:59:14 +0100    original pom.xml (hrotkog) +
+2015-03-24 14:35:15 +0100    maven 3.1 artifactId change, add default plugin execution (hrotkog) +
+2015-03-24 14:00:29 +0100    add bugzilla link converter (hrotkog) +
+2015-03-24 11:06:12 +0100    maven 3.1 artifactId change, add default plugin execution (hrotkog) +
+2015-03-23 12:14:38 +0100    Generate clean HTML (Manuel) +
+
+*maven-gitlog-plugin-1.9.0* +
+*maven-gitlog-plugin-1.9.1* +
+2015-03-14 13:11:30 +0100    Fixed the version (Daniel Flower) +
+
+*maven-gitlog-plugin-1.8.0.0* +
+2015-03-14 13:04:07 +0100    Fixed SCM typo (Daniel Flower) +
+2015-03-14 12:59:04 +0100    Updated documentation (Daniel Flower) +
+2015-03-14 12:46:49 +0100    Updated all the plugins, changed to annotation-based declarations on the mojo, and created a Maven site (Daniel Flower) +
+2015-03-12 13:54:01 +0100    Add escapes for tab "\t", backspace "\b", form feed "\f" and carriage return "\r", may create invalid JSON that can't be parsed otherwise. (Kristoffer Lundén) +
+
+*maven-gitlog-plugin-1.7.0* +
+2014-05-25 14:53:01 +0200    Updated the version in preparation of release (Daniel Flower) +
+2014-04-25 22:54:08 +0200    add json file renderer (Keegan Roth) +
+2014-04-25 21:57:28 +0200    refactor resource loading into method in parent for re-use (Keegan Roth) +
+2014-04-25 21:28:31 +0200    remove resource leak warning in FileRenderer.convertStreamToString() (Keegan Roth) +
+2014-04-25 21:27:11 +0200    move convertStreamToString() to parent class for re-use (Keegan Roth) +
+2014-04-10 16:11:18 +0200    Updated version to use in readme (Daniel Flower) +
+
+*maven-gitlog-plugin-1.6.0* +
+2014-04-10 16:00:15 +0200    Bumping minor version for new feature (Daniel Flower) +
+2014-04-07 17:46:59 +0200    Include example of how to use an artifact that contains additional filters (Ivan Martinez-Ortiz) +
+2014-04-07 17:43:13 +0200    Include example of how to override includeCommitsAfter parameter. (Ivan Martinez-Ortiz) +
+2014-03-31 15:26:10 +0200    Add showCommitsAfter parameter to include in the changelog commits only with a timestamp after the provided parameter value. (Ivan Martinez-Ortiz) +
+2014-03-20 23:25:07 +0100    Add SPI loading mechanism for CommitFilters. (Ivan Martinez-Ortiz) +
+
+*maven-gitlog-plugin-1.5.2* +
+2013-10-21 16:30:31 +0200    Bumping readme version in anticipation of next release (Daniel Flower) +
+
+*maven-gitlog-plugin-1.5.1* +
+2013-10-21 16:05:20 +0200    Bumped version in readme in anticipation of upcoming release (Daniel Flower) +
+2013-10-20 16:39:38 +0200    bump eclipse.jgit version (Artem Koshelev) +
+2013-10-20 12:16:10 +0200    update readme (Artem Koshelev) +
+2013-10-20 12:08:44 +0200    add hamcrest dependency (Artem Koshelev) +
+2013-10-20 11:48:07 +0200    fix - create default date format (Artem Koshelev) +
+2013-10-20 11:42:32 +0200    provide ability to setup date format in Formatter add tests for Formatter bump up junit version to 4.11 use junit4 assertions in all tests (Artem Koshelev) +
+2013-10-19 13:47:17 +0200    move hardcoded strings to constants (Artem Koshelev) +
+2013-01-12 05:59:52 +0100    Removing intellij files from maven repo. Better to be IDE agnostic. (Daniel Flower) +
+2013-01-12 05:53:01 +0100    Fixed typo in markdown link... getting there.... (Daniel Flower) +
+2013-01-12 05:52:01 +0100    Updated plugin verison to use in the readme to 1.5.0 which is the first version to support markdown generation. (Daniel Flower) +
+
+*maven-gitlog-plugin-1.5.0* +
+2013-01-12 05:41:18 +0100    Added link to markdown sample in the readme (Daniel Flower) +
+2013-01-12 05:35:26 +0100    Creating markdown sample (Daniel Flower) +
+2013-01-12 05:31:10 +0100    Adding travis-ci build status to readme (Daniel Flower) +
+2013-01-12 05:24:06 +0100    Adding travis-ci build (Daniel Flower) +
+2013-01-06 22:07:48 +0100    Refactored code for easier testing. Added test cases for the markdown renderer and the markdown link converter. OPEN - task 10: Generate markdown formatted gitlog  https://github.com/danielflower/maven-gitlog-plugin/issues/issue/10 (Gerd Zanker) +
+2013-01-05 14:12:46 +0100    OPEN - task 10: Generate markdown formatted gitlog  https://github.com/danielflower/maven-gitlog-plugin/issues/issue/10 Implemented markdown renderer and simple tests. Updated readme with new available maven plugin parameters. (Gerd Zanker) +
+
+*maven-gitlog-plugin-1.4.11* +
+2012-03-17 07:33:55 +0100    Updated maven version in docs (Daniel Flower) +
+
+*maven-gitlog-plugin-1.4.10* +
+2012-03-17 07:06:40 +0100    Updated maven version in readme (Daniel Flower) +
+2012-03-17 07:02:48 +0100    Random intellij updates (Daniel Flower) +
+2012-03-15 01:21:28 +0100    Added property to configure use of full git message (James Rawlings) +
+
+*maven-gitlog-plugin-1.4.9* +
+2011-09-21 15:56:28 +0200    Allow generation of table-only HTML reports. Closes https://github.com/danielflower/maven-gitlog-plugin/issues/7[#7] (Daniel Flower) +
+
+*maven-gitlog-plugin-1.4.8* +
+2011-09-19 16:17:47 +0200    Added links to example reports (Daniel Flower) +
+
+*maven-gitlog-plugin-1.4.7* +
+2011-09-19 15:17:29 +0200    Preparing for initial release to OSS repository (Daniel Flower) +
+2011-09-18 11:01:05 +0200    https://github.com/danielflower/maven-gitlog-plugin/issues/3[#3] Adding support for issue management tools. Updated documentation. Closes https://github.com/danielflower/maven-gitlog-plugin/issues/3[#3] (Daniel Flower) +
+2011-09-18 10:54:22 +0200    https://github.com/danielflower/maven-gitlog-plugin/issues/3[#3] Adding support for issue management tools (Daniel Flower) +
+2011-09-18 10:52:47 +0200    https://github.com/danielflower/maven-gitlog-plugin/issues/3[#3] Adding support for issue management tools and added config as described in https://github.com/danielflower/maven-gitlog-plugin/issues/4[gh-4] (a.k.a https://github.com/danielflower/maven-gitlog-plugin/issues/4[GH-4]/https://github.com/danielflower/maven-gitlog-plugin/issues/4[#4]) (Daniel Flower) +
+2011-09-18 10:48:14 +0200    https://github.com/danielflower/maven-gitlog-plugin/issues/3[#3] Adding support for issue management tools (Daniel Flower) +
+2011-09-18 09:17:45 +0200    Added author to plaintext renderer (Daniel Flower) +
+2011-09-18 08:50:07 +0200    https://github.com/danielflower/maven-gitlog-plugin/issues/3[#3] Fix whitespace issues in HTML (Daniel Flower) +
+2011-09-18 08:36:21 +0200    https://github.com/danielflower/maven-gitlog-plugin/issues/3[#3] The HTML renderer should HTML-encode tags like <this>, or < or > signs, or & => &amp;, and also " => &quot; etc (Daniel Flower) +
+
+*maven-gitlog-plugin-1.4.5* +
+2011-09-18 08:12:09 +0200    Added instructions on how to run the show goal (Daniel Flower) +
+2011-09-18 08:06:08 +0200    Rearranged packages (Daniel Flower) +
+2011-09-18 07:58:03 +0200    Filter out merge commits from the changelog.  Closes https://github.com/danielflower/maven-gitlog-plugin/issues/6[#6] (Daniel Flower) +
+2011-09-18 07:49:22 +0200    Fixed comment in unit test (master) (Daniel Flower) +
+2011-09-18 07:47:39 +0200    Cleaned up HTML (Daniel Flower) +
+2011-09-18 07:45:41 +0200    Preparing for release (Daniel Flower) +
+2011-09-18 06:09:54 +0200    Fixed groupid and added new show goal (Daniel Flower) +
+2011-09-17 18:21:12 +0200    https://github.com/danielflower/maven-gitlog-plugin/issues/4[#4] Fixed name of README file (Daniel Flower) +
+2011-09-17 18:19:57 +0200    https://github.com/danielflower/maven-gitlog-plugin/issues/4[#4] Allow configuration of renderers (Daniel Flower) +
+2011-09-17 16:21:36 +0200    https://github.com/danielflower/maven-gitlog-plugin/issues/3[#3] Added Simple HTML formatter (Daniel Flower) +
+2011-09-17 15:23:30 +0200    Cleaned up access modifiers (Daniel Flower) +
+2011-09-17 12:17:16 +0200    https://github.com/danielflower/maven-gitlog-plugin/issues/4[gh-4] Fixed bug in filtering when there are multiple renderers (Daniel Flower) +
+2011-09-17 11:48:10 +0200    https://github.com/danielflower/maven-gitlog-plugin/issues/4[GH-4] Improve the error reporting for when no git repository is found (Daniel Flower) +
+2011-09-17 11:30:35 +0200    https://github.com/danielflower/maven-gitlog-plugin/issues/4[#4] Set up the GenerateMojo to execute the plugin (Daniel Flower) +
+2011-09-17 11:15:12 +0200    Fixed issue management node (Daniel Flower) +
+2011-09-17 11:06:07 +0200    Do not show maven release plugin messages.  Closes https://github.com/danielflower/maven-gitlog-plugin/issues/1[GH-1] (Daniel Flower) +
+2011-09-17 11:00:46 +0200    Do not show duplicate commit messages.  Closes https://github.com/danielflower/maven-gitlog-plugin/issues/2[#2] (Daniel Flower) +
+2011-09-17 10:47:53 +0200    Fixed some project setup issues (Daniel Flower) +
+
+*maven-gitlog-plugin-1.2* +
+2011-09-17 10:09:37 +0200    Temporarily adding local repository for deployments (Daniel Flower) +
+
+*maven-gitlog-plugin-1.1* +
+2011-09-17 09:54:53 +0200    Fixing maven release issues (Daniel Flower) +
+2011-09-17 09:53:21 +0200    Fixed github repo URLs (Daniel Flower) +
+2011-09-17 09:42:49 +0200    Got PlainText renderer working (Daniel Flower) +
+2011-09-17 09:18:59 +0200    Refactored sout logger to use the maven log interface (Daniel Flower) +
+2011-09-17 09:03:09 +0200    Added support for reading annotated tags (Daniel Flower) +
+2011-09-17 07:10:35 +0200    Renaming project (Daniel Flower) +
+2011-09-16 20:42:36 +0200    Can write the list of commits (Daniel Flower) +
+2011-09-16 20:31:45 +0200    Initial attempt to use jgit (Daniel Flower) +
+2011-09-16 19:38:24 +0200    Got initial mojo set up to write to a text file (Daniel Flower) +
+2011-09-16 18:58:33 +0200    Initial maven setup (Daniel Flower) +
+2011-09-16 18:26:19 +0200    first commit (Daniel Flower) +

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -29,6 +29,7 @@
 			<item name="HTML" href="samples/changelog.html" />
 			<item name="HTML table" href="samples/changelogtable.html" />
 			<item name="Markdown" href="samples/changelog.md" />
+			<item name="Asciidoc" href="samples/changelog.adoc" />
 			<item name="JSON" href="samples/changelog.json" />
 			<item name="Plain text" href="samples/changelog.txt" />
 		</menu>

--- a/src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java
@@ -91,7 +91,16 @@ public class GeneratorTest {
         generateReport(log, renderer);
     }
 
-    @Test
+	@Test
+	public void writeAsciidocLogToFile() throws Exception {
+		Log log = new SystemStreamLog();
+		GitHubIssueLinkConverter messageConverter = new GitHubIssueLinkConverter(log, THIS_PLUGIN_ISSUES);
+		ChangeLogRenderer renderer = new AsciidocRenderer(log, new File(TARGET_DIR), "changelog.adoc", false, messageConverter);
+		generateReport(log, renderer);
+	}
+
+
+	@Test
     public void writeJsonLogToFile() throws Exception {
         Log log = new SystemStreamLog();
         ChangeLogRenderer renderer = new JsonRenderer(log, new File(TARGET_DIR), "changelog.json", false);

--- a/src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/AsciidocLinkConverterTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/AsciidocLinkConverterTest.java
@@ -1,0 +1,38 @@
+package com.github.danielflower.mavenplugins.gitlog.renderers;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class AsciidocLinkConverterTest {
+
+	private AsciidocLinkConverter converter = new AsciidocLinkConverter(null);
+
+	@Test
+	public void emptyMessagesAreUnchanged() {
+		test("", "");
+	}
+
+	@Test
+	public void noItemReferencesReturnsMessagesAreUnchanged() {
+		String someMessage = "This is some #1 gh-2 conf-3 CONF- message JIRA-YO";
+		test(someMessage, someMessage);
+	}
+
+	@Test
+	public void HyperlinkAtBeginningIsRendered() {
+		test("<a href=\"URL\">Text</a> and some message", "URL[Text] and some message");
+	}
+
+	@Test
+	public void multipleHyperlinksAreRendered() {
+		test("First a link <a href=\"URL1\">Text1</a> a scond one <a href=\"URL2\">Text2</a> and the end.", 
+			 "First a link URL1[Text1] a scond one URL2[Text2] and the end.");
+	}
+
+	private void test(String input, String expectedOutput) {
+		String actual = converter.formatCommitMessage(input);
+		assertEquals("Input: " + input, expectedOutput, actual);
+	}
+
+}


### PR DESCRIPTION
I added Asciidoc converter support as it becomes more and more used today.
I attached a capture of a sample Asciidoc (HTML generated) documentation. 
All tests are passing and I think I added links and documentation everywhere but tell me if you think I missed something !

![gitlog-maven-plugin-adoc-example](https://cloud.githubusercontent.com/assets/5528566/18752868/047f85ae-80e4-11e6-8864-847d6a5756c2.PNG)
