### PR TITLE
[evol] Add a new report type FullHTML + Add the parameter includeOnly…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.danielflower.mavenplugins</groupId>
   <artifactId>gitlog-maven-plugin</artifactId>
-  <version>1.13-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
   <name>Maven Git Log Plugin</name>
   <description>Generates a changelog based on commits to a git repository in text and HTML format showing the changes
@@ -313,7 +313,7 @@
 					<plugin>
 						<groupId>com.github.danielflower.mavenplugins</groupId>
 						<artifactId>gitlog-maven-plugin</artifactId>
-						<version>${project.version}</version>
+						<version>2.0.0-SNAPSHOT</version>
 						<inherited>false</inherited>
 						<configuration>
 							<reportTitle>Projet : ${project.groupId}:${project.artifactId} Version : ${project.version}</reportTitle>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,21 @@
       <artifactId>xml-apis</artifactId>
       <version>1.3.04</version>
     </dependency>
+    
+<!--  dependency of maven deploy -->
+      
+       <dependency>
+	       <groupId>org.apache.maven</groupId>
+	       <artifactId>maven-artifact</artifactId>
+	       <version>2.2.1</version>
+     </dependency>
+	
+	<dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>1.5.15</version>
+</dependency>
+
   </dependencies>
   <build>
     <plugins>
@@ -291,5 +306,36 @@
         </plugins>
       </build>
     </profile>
+   	<profile>
+			<id>CHANGE-LOG</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.github.danielflower.mavenplugins</groupId>
+						<artifactId>gitlog-maven-plugin</artifactId>
+						<version>${project.version}</version>
+						<inherited>false</inherited>
+						<configuration>
+							<reportTitle>Projet : ${project.groupId}:${project.artifactId} Version : ${project.version}</reportTitle>
+							<verbose>true</verbose>
+							<outputDirectory>${project.build.directory}/docs</outputDirectory>
+							<generateSimpleHTMLChangeLog>true</generateSimpleHTMLChangeLog>
+							<simpleHTMLChangeLogFilename>simplechangelog.html</simpleHTMLChangeLogFilename>
+							<includeOnlyCommitsAfterRelease>false</includeOnlyCommitsAfterRelease>
+							<fullGitMessage>true</fullGitMessage>
+							<dateFormat>yyyy-MM-dd HH:mm:ss</dateFormat>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>generate</goal>
+									<goal>deploy</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -329,7 +329,7 @@
 							<execution>
 								<goals>
 									<goal>generate</goal>
-									<goal>deploy</goal>
+									<goal>install</goal>
 								</goals>
 							</execution>
 						</executions>

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/ConfigProperties.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/ConfigProperties.java
@@ -1,0 +1,30 @@
+package com.github.danielflower.mavenplugins.gitlog;
+
+
+import java.util.ResourceBundle;
+
+
+
+
+public class ConfigProperties
+  
+
+{
+	private static final ResourceBundle params = ResourceBundle.getBundle ("configuration");
+  
+	 public static String getProperty(String cle_)
+	 {
+	      return params.getString(cle_);
+	 }
+	 public static String getExistingProperty(String cle_)
+	 {
+	      String valeur = getProperty(cle_);
+	      if (valeur == null || valeur.length() == 0)
+	      {
+	         throw new IllegalStateException("Configuration - Parametre '" + cle_ + "' introuvable ou non renseigne");
+	      }
+	      return valeur;
+	 }
+
+}
+

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/DeployReportMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/DeployReportMojo.java
@@ -1,0 +1,254 @@
+package com.github.danielflower.mavenplugins.gitlog;
+
+import java.io.File;
+import java.util.Map;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.factory.ArtifactFactory;
+import org.apache.maven.artifact.installer.ArtifactInstallationException;
+import org.apache.maven.artifact.installer.ArtifactInstaller;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * install the report in the local repository.
+ * 
+ * @author <a href="mailto:aramirez@apache.org">Allan Ramirez</a>
+ */
+@Mojo(name = "deploy", defaultPhase = LifecyclePhase.PACKAGE, aggregator = true)
+public class DeployReportMojo extends AbstractMojo {
+
+	/**
+	 * GroupId of the artifact to be deployed. Retrieved from POM file if
+	 * specified.
+	 * 
+	 */
+	@Parameter(property = "project.groupId")
+	private String groupId;
+
+	/**
+	 * ArtifactId of the artifact to be deployed. Retrieved from POM file if
+	 * specified.
+	 */
+	@Parameter(property = "project.artifactId")
+	private String artifactId;
+
+	/**
+	 * Version of the artifact to be deployed. Retrieved from POM file if
+	 * specified.
+	 * 
+	 */
+	@Parameter(property = "project.version")
+	private String version;
+
+	/**
+	 * report type"
+	 */
+	@Parameter(defaultValue = "html")
+	private String packaging;
+
+	/**
+	 * Server Id to map on the &lt;id&gt; under &lt;server&gt; section of
+	 * settings.xml In most cases, this parameter will be required for
+	 * authentication.
+	 */
+	@Parameter(property = "project.distributionManagementArtifactRepository.id")
+	private String repositoryId;
+
+	/**
+	 * The type of remote repository layout to deploy to. Try <i>legacy</i> for
+	 * a Maven 1.x-style repository layout.
+	 */
+	@Parameter(defaultValue = "default")
+	private String repositoryLayout;
+
+	/**
+	 * URL where the artifact will be deployed. <br/>
+	 * ie ( file:///C:/m2-repo or scp://host.com/path/to/repo )
+	 * 
+	 * @parameter 
+	 *            expression="${project.distributionManagementArtifactRepository.url}"
+	 */
+	@Parameter(property = "project.distributionManagementArtifactRepository.url")
+	private String url;
+
+	/**
+	 * Add classifier to the artifact
+	 */
+	@Parameter(defaultValue = "report")
+	private String classifier;
+
+	/**
+	 * Whether to deploy snapshots with a unique version or not.
+	 */
+	@Parameter(defaultValue = "true")
+	private boolean uniqueVersion;
+
+	/**
+	 * The directory to put the reports in. Defaults to the project build
+	 * directory (normally target).
+	 * 
+	 */
+	@Parameter(property = "project.build.directory")
+	private File outputDirectory;
+
+	/**
+	 * The filename of the simple HTML changelog, if generated.
+	 * 
+	 */
+	@Parameter(defaultValue = "changelog.html")
+	private String fullHTMLChangeLogFilename;
+
+	/**
+	 * Component used to create an artifact.
+	 */
+	@Component
+	protected ArtifactFactory artifactFactory;
+
+	@Component
+	protected ArtifactInstaller installer;
+
+	@Component
+	private Map<String, ArtifactRepositoryLayout> repositoryLayouts;
+
+	@Parameter(property = "localRepository")
+	private ArtifactRepository localRepository;
+
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		File file = new File(this.outputDirectory,
+				this.fullHTMLChangeLogFilename);
+		if (!file.exists()) {
+			throw new MojoExecutionException(file.getPath() + " not found.");
+		}
+
+		// Create the artifact
+		Artifact artifact = artifactFactory.createArtifactWithClassifier(
+				groupId, artifactId, version, packaging, classifier);
+
+		try {
+			installer.install(file, artifact, getLocalRepository());
+		} catch (ArtifactInstallationException e) {
+			// TODO Auto-generated catch block
+			throw new MojoExecutionException("Error installing artifact '"
+					+ artifact.getDependencyConflictId() + "': "
+					+ e.getMessage(), e);
+		}
+
+	}
+
+	void setGroupId(String groupId) {
+		this.groupId = groupId;
+	}
+
+	void setArtifactId(String artifactId) {
+		this.artifactId = artifactId;
+	}
+
+	void setVersion(String version) {
+		this.version = version;
+	}
+
+	void setPackaging(String packaging) {
+		this.packaging = packaging;
+	}
+
+	String getGroupId() {
+		return groupId;
+	}
+
+	String getArtifactId() {
+		return artifactId;
+	}
+
+	String getVersion() {
+		return version;
+	}
+
+	String getPackaging() {
+		return packaging;
+	}
+
+	String getClassifier() {
+		return classifier;
+	}
+
+	void setClassifier(String classifier) {
+		this.classifier = classifier;
+	}
+
+	public ArtifactRepository getLocalRepository() {
+		return localRepository;
+	}
+
+	public void setLocalRepository(ArtifactRepository localRepository) {
+		this.localRepository = localRepository;
+	}
+
+	ArtifactRepositoryLayout getLayout(String id) throws MojoExecutionException {
+		ArtifactRepositoryLayout layout = repositoryLayouts.get(id);
+
+		if (layout == null) {
+			throw new MojoExecutionException("Invalid repository layout: " + id);
+		}
+
+		return layout;
+	}
+
+	public File getOutputDirectory() {
+		return outputDirectory;
+	}
+
+	public void setOutputDirectory(File outputDirectory) {
+		this.outputDirectory = outputDirectory;
+	}
+
+	
+
+	public String getUrl() {
+		return url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+	public boolean isUniqueVersion() {
+		return uniqueVersion;
+	}
+
+	public void setUniqueVersion(boolean uniqueVersion) {
+		this.uniqueVersion = uniqueVersion;
+	}
+
+	public ArtifactFactory getArtifactFactory() {
+		return artifactFactory;
+	}
+
+	public void setArtifactFactory(ArtifactFactory artifactFactory) {
+		this.artifactFactory = artifactFactory;
+	}
+
+	public Map<String, ArtifactRepositoryLayout> getRepositoryLayouts() {
+		return repositoryLayouts;
+	}
+
+	public void setRepositoryLayouts(
+			Map<String, ArtifactRepositoryLayout> repositoryLayouts) {
+		this.repositoryLayouts = repositoryLayouts;
+	}
+
+	public ArtifactInstaller getInstaller() {
+		return installer;
+	}
+
+	public void setInstaller(ArtifactInstaller installer) {
+		this.installer = installer;
+	}
+}

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
@@ -83,14 +83,26 @@ public class GenerateMojo extends AbstractMojo {
 	/**
 	 * If true, then a simple HTML changelog will be generated.
 	 */
-	@Parameter(defaultValue = "true")
+	@Parameter(defaultValue = "false")
 	private boolean generateSimpleHTMLChangeLog;
+	
+	/**
+	 * If true, then a full HTML changelog will be generated.
+	 */
+	@Parameter(defaultValue = "true")
+	private boolean generateFullHTMLChangeLog;
 
 	/**
 	 * The filename of the simple HTML changelog, if generated.
 	 */
-	@Parameter(defaultValue = "changelog.html")
+	@Parameter(defaultValue = "simplechangelog.html")
 	private String simpleHTMLChangeLogFilename;
+	
+	/**
+	 * The filename of the simple HTML changelog, if generated.
+	 */
+	@Parameter(defaultValue = "changelog.html")
+	private String fullHTMLChangeLogFilename;
 
 	/**
 	 * If true, then an HTML changelog which contains only a table element will be generated.
@@ -187,6 +199,18 @@ public class GenerateMojo extends AbstractMojo {
 	 */
 	@Parameter
 	private String path;
+	
+	/**
+	 * Include in the changelog the commits after the last release
+	 */
+	@Parameter(defaultValue = "false")
+	private boolean includeOnlyCommitsAfterRelease;
+	
+	/**
+	 * the tag name of release
+	 */
+	@Parameter(defaultValue = "releaseTag_")
+	private String nameTagRelease;
 
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
@@ -239,7 +263,9 @@ public class GenerateMojo extends AbstractMojo {
 		}
 
 		try {
-			generator.generate(reportTitle, includeCommitsAfter);
+		
+			generator.generate(reportTitle, repository ,includeOnlyCommitsAfterRelease ,nameTagRelease);
+			
 		} catch (IOException e) {
 			getLog().warn("Error while generating gitlog.  Some changelogs may be incomplete or corrupt.", e);
 		}
@@ -252,8 +278,11 @@ public class GenerateMojo extends AbstractMojo {
 			renderers.add(new PlainTextRenderer(getLog(), outputDirectory, plainTextChangeLogFilename, fullGitMessage));
 		}
 
-		if (generateSimpleHTMLChangeLog || generateHTMLTableOnlyChangeLog || generateMarkdownChangeLog || generatAsciidocChangeLog) {
+		if (generateFullHTMLChangeLog || generateSimpleHTMLChangeLog || generateHTMLTableOnlyChangeLog || generateMarkdownChangeLog || generatAsciidocChangeLog) {
 			MessageConverter messageConverter = getCommitMessageConverter();
+			if (generateFullHTMLChangeLog) {
+				renderers.add(new FullHtmlRenderer(getLog(), outputDirectory, fullHTMLChangeLogFilename, fullGitMessage, messageConverter, false));
+			}
 			if (generateSimpleHTMLChangeLog) {
 				renderers.add(new SimpleHtmlRenderer(getLog(), outputDirectory, simpleHTMLChangeLogFilename, fullGitMessage, messageConverter, false));
 			}

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
@@ -95,13 +95,13 @@ public class GenerateMojo extends AbstractMojo {
 	/**
 	 * The filename of the simple HTML changelog, if generated.
 	 */
-	@Parameter(defaultValue = "simplechangelog.html")
+	@Parameter(defaultValue = "changelog.html")
 	private String simpleHTMLChangeLogFilename;
 	
 	/**
 	 * The filename of the simple HTML changelog, if generated.
 	 */
-	@Parameter(defaultValue = "changelog.html")
+	@Parameter(defaultValue = "changelogfull.html")
 	private String fullHTMLChangeLogFilename;
 
 	/**

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/InstallReportMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/InstallReportMojo.java
@@ -22,8 +22,8 @@ import org.apache.maven.plugins.annotations.Parameter;
  * 
  * @author <a href="mailto:aramirez@apache.org">Allan Ramirez</a>
  */
-@Mojo(name = "deploy", defaultPhase = LifecyclePhase.PACKAGE, aggregator = true)
-public class DeployReportMojo extends AbstractMojo {
+@Mojo(name = "install", defaultPhase = LifecyclePhase.PACKAGE, aggregator = true)
+public class InstallReportMojo extends AbstractMojo {
 
 	/**
 	 * GroupId of the artifact to be deployed. Retrieved from POM file if

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/InstallReportMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/InstallReportMojo.java
@@ -103,7 +103,7 @@ public class InstallReportMojo extends AbstractMojo {
 	 * The filename of the simple HTML changelog, if generated.
 	 * 
 	 */
-	@Parameter(defaultValue = "changelog.html")
+	@Parameter(defaultValue = "changelogfull.html")
 	private String fullHTMLChangeLogFilename;
 
 	/**

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/DuplicateCommitMessageFilter.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/DuplicateCommitMessageFilter.java
@@ -9,7 +9,7 @@ public class DuplicateCommitMessageFilter implements CommitFilter {
 	@Override
 	public boolean renderCommit(RevCommit commit) {
 		boolean isDuplicate = previous != null
-				&& messagesEquivalent(commit.getShortMessage(), previous.getShortMessage());
+				&& messagesEquivalent(commit.getName(), previous.getName());
 		previous = commit;
 		return !isDuplicate;
 	}

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/ChangeLogRenderer.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/ChangeLogRenderer.java
@@ -2,8 +2,10 @@ package com.github.danielflower.mavenplugins.gitlog.renderers;
 
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevTag;
+import org.eclipse.jgit.diff.DiffEntry;
 
 import java.io.IOException;
+import java.util.List;
 
 public interface ChangeLogRenderer {
 
@@ -16,5 +18,9 @@ public interface ChangeLogRenderer {
 	public void renderFooter() throws IOException;
 
 	public void close();
+	
+	public void setListDiffEntry( List<DiffEntry> listDiffEntry);
+	
+	public  List <DiffEntry> getListDiffEntry();
 
 }

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/FileRenderer.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/FileRenderer.java
@@ -8,11 +8,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
 import java.util.Scanner;
+import org.eclipse.jgit.diff.DiffEntry;
+import java.util.List;
 
 public abstract class FileRenderer implements ChangeLogRenderer {
 
 	protected Writer writer;
 	protected final Log log;
+	protected List <DiffEntry> listDiffEntry;
 
 	public FileRenderer(Log log, File targetFolder, String filename) throws IOException {
 		this.log = log;
@@ -50,4 +53,13 @@ public abstract class FileRenderer implements ChangeLogRenderer {
 		return s;
 	}
 
+	public void setListDiffEntry(List<DiffEntry> i_listDiffEntry)
+
+	{
+		listDiffEntry = i_listDiffEntry;
+	}
+
+	public List<DiffEntry> getListDiffEntry() {
+		return listDiffEntry;
+	}
 }

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/FullHtmlRenderer.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/FullHtmlRenderer.java
@@ -1,0 +1,170 @@
+package com.github.danielflower.mavenplugins.gitlog.renderers;
+
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugin.logging.Log;
+import org.codehaus.plexus.util.FileUtils;
+import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevTag;
+
+import com.github.danielflower.mavenplugins.gitlog.ConfigProperties;
+
+import java.io.File;
+import java.io.IOException;
+
+import static com.github.danielflower.mavenplugins.gitlog.renderers.Formatter.NEW_LINE;
+
+public class FullHtmlRenderer extends FileRenderer {
+
+	private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+	private String title;
+	private String template;
+	protected StringBuilder tableHtml = new StringBuilder();
+	protected final MessageConverter messageConverter;
+	private final boolean tableOnly;
+	private final boolean fullGitMessage;
+
+	public FullHtmlRenderer(Log log, File targetFolder, String filename, boolean fullGitMessage, MessageConverter messageConverter, boolean tableOnly) throws IOException {
+		super(log, targetFolder, filename);
+		this.messageConverter = messageConverter;
+		this.tableOnly = tableOnly;
+		this.fullGitMessage = fullGitMessage;
+
+		if (!tableOnly) {
+			FileUtils.copyURLToFile(getClass().getResource("/html/css/gitlog.css"), new File(targetFolder, "/css/gitlog.css"));
+			this.template = loadResourceToString("/html/FullHtmlTemplate.html");
+		}
+
+	}
+
+	protected static String htmlEncode(String input) {
+		input = StringEscapeUtils.escapeHtml4(input);
+		return input.replaceAll(System.getProperty("line.separator"), "<br/>");
+	}
+
+	@Override
+	public void renderHeader(String reportTitle) throws IOException {
+		this.title = reportTitle;
+		tableHtml.append("\t<table >")
+				.append(NEW_LINE)
+				.append("\t\t<tbody>")
+				.append(NEW_LINE)
+				.append("<thead>")
+				.append("\t\t<tr>")
+				.append("<th>").append(ConfigProperties.getExistingProperty("colonne.date")).append("</th>")
+				.append("<th>").append(ConfigProperties.getExistingProperty("colonne.author")).append("</th>")
+				.append("<th>").append(ConfigProperties.getExistingProperty("colonne.message")).append("</th>")	
+				.append("<th>").append(ConfigProperties.getExistingProperty("colonne.files")).append("</th>")
+				.append("</tr>").append("</thead>").append(NEW_LINE);;
+	}
+
+	@Override
+	public void renderTag(RevTag tag) throws IOException {
+		tableHtml.append("\t\t<tr class=\"tag\"><td colspan=\"4\">")
+				.append(SimpleHtmlRenderer.htmlEncode("Tag : " +tag.getTagName()))
+				.append("</td></tr>")
+				.append(NEW_LINE);
+	}
+
+	@Override
+	public void renderCommit(RevCommit commit) throws IOException {
+		String date = Formatter.formatDateTime(commit.getCommitTime());
+		String message = null;
+		if (fullGitMessage){
+			message = messageConverter.formatCommitMessage(formatLongMessage(commit.getFullMessage()));
+		} else {
+			message = messageConverter.formatCommitMessage(htmlEncode(commit.getShortMessage()));
+		}
+
+		String author = SimpleHtmlRenderer.htmlEncode(commit.getCommitterIdent().getName());
+		String committer = SimpleHtmlRenderer.htmlEncode(commit.getCommitterIdent().getName());
+		String authorHtml = "<span class=\"committer\">" + commit.getAuthorIdent().getName() + "</span>";
+		if (!areSame(author, committer)) {
+			authorHtml += "and <span class=\"author\">" + author + "</span>";
+		}
+
+		tableHtml.append("\t\t<tr>")
+				.append("<td class=\"date\">").append(date).append("</td>")
+				.append("<td>").append(authorHtml).append("</td>")
+				.append("<td>").append(message).append("</td>")
+				.append("<td>").append(convertListToLinges ()).append("</td>")
+				.append("</tr>").append(NEW_LINE);
+	}
+
+	private String formatLongMessage(String gitMessage) {
+		String lines[] = StringEscapeUtils.escapeHtml4(gitMessage).split(LINE_SEPARATOR);
+		if (lines.length <=1) {
+			return gitMessage;
+		}
+		StringBuilder builder = new StringBuilder();
+		for (int i = 0; i < lines.length; i++) {
+			if (i == 0) {
+				builder.append(lines[i]).append("</br><span class='commitDetails'>");
+			} else {
+				builder.append(lines[i]).append("</br>");
+			}
+		}
+		return builder.append("</span>").toString();
+	}
+
+	@Override
+	public void renderFooter() throws IOException {
+		tableHtml.append("\t\t</tbody>")
+				.append(NEW_LINE)
+				.append("\t</table>")
+				.append(NEW_LINE);
+
+		if (tableOnly) {
+			writer.append(tableHtml.toString());
+		} else {
+			
+			int index = title.indexOf("Version");
+			String titre1=title;
+			String titre2="";
+			if (index != -1)
+			{
+				 titre1 = title.substring(0, index);
+
+				titre2 = title.substring(index, title.length());
+			}
+			String html = template
+					.replace("{title}", htmlEncode(titre1))
+					.replace("{title2}", htmlEncode(titre2))
+					.replace("{table}", tableHtml.toString());
+			writer.append(html);
+		}
+	}
+
+	private boolean areSame(String author, String committer) {
+		return ("" + author).toLowerCase().equals("" + committer.toLowerCase());
+	}
+
+	private String convertListToLinges() {
+		StringBuilder lignesFiles = new StringBuilder();
+		if (this.getListDiffEntry()!=null &&this.getListDiffEntry().size() == 1) {
+
+			return StringUtils.substring(this.getListDiffEntry().get(0)
+					.toString(), 9);
+		} else if (this.getListDiffEntry()!=null && this.getListDiffEntry().size() > 1) {
+			lignesFiles.append(StringUtils.substring(this.getListDiffEntry().get(0).toString(), 9))
+			.append("</br>");
+			int idex=0;
+			lignesFiles.append("<details> <summary>"
+					+ ConfigProperties.getExistingProperty("bouton.detail")
+					+ ": </summary>");
+
+			for (DiffEntry diff : this.getListDiffEntry()) {
+			    if(idex!=0)
+			    {
+				lignesFiles.append(StringUtils.substring(diff.toString(), 9))
+						.append("</br>");
+			    }
+			    idex++;
+			}
+			lignesFiles.append("</details>");
+			return lignesFiles.toString();
+		}
+		return "";
+	}
+}

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/MavenLoggerRenderer.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/MavenLoggerRenderer.java
@@ -2,10 +2,12 @@ package com.github.danielflower.mavenplugins.gitlog.renderers;
 
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevTag;
 
 import java.io.IOException;
+import java.util.List;
 
 public class MavenLoggerRenderer implements ChangeLogRenderer {
 
@@ -45,5 +47,17 @@ public class MavenLoggerRenderer implements ChangeLogRenderer {
 	}
 
 	public void close() {
+	}
+
+	@Override
+	public void setListDiffEntry(List<DiffEntry> listDiffEntry) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public List<DiffEntry> getListDiffEntry() {
+		// TODO Auto-generated method stub
+		return null;
 	}
 }

--- a/src/main/resources/configuration.properties
+++ b/src/main/resources/configuration.properties
@@ -1,0 +1,8 @@
+colonne.date=Date
+colonne.message=Message
+colonne.author=Author
+colonne.files=Files
+bouton.detail=Show all files
+
+filtre.maven.release=[maven-release-plugin]
+last.commit.maven.release=[maven-release-plugin] prepare for next development

--- a/src/main/resources/html/FullHtmlTemplate.html
+++ b/src/main/resources/html/FullHtmlTemplate.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- saved from url=(0048)http://openweb.eu.org/IMG/article90/annexe2.html -->
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<meta charset="UTF-8"/>
+<link rel="stylesheet" type="text/css" href="css/gitlog.css"/>
+<style type="text/css">
+
+
+.changelog{
+
+    width:auto;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+		table {
+border:3px solid #000000;
+border-collapse:collapse;
+width:90%;
+margin:auto;
+}
+thead, tfoot {
+background-color:#4D4D4D;
+border:1px solid #4D4D4D;
+}
+tbody {
+background-color:#FFFFFF;
+border:1px solid #333;
+}
+th {
+font-family:monospace;
+border:1px dotted #333;
+padding:5px;
+color: white;
+width:auto;
+}
+td {
+font-family:sans-serif;
+font-size:80%;
+border:1px solid #333;
+padding:5px;
+text-align:left;
+}
+caption {
+font-family:sans-serif;
+}
+
+		details {
+	display:block;  
+}
+summary {
+	display:block; 
+	background:#FFFFFF;
+	color: #663300 ;
+	
+	cursor:pointer;font-weight:bold;
+}
+h1 {
+    font-family: Times New Roman, Times, serif;
+    font-style: normal;
+    font-weight: bold;
+    font-size: 14pt;
+    color: #000;
+    text-align: center;
+    border-style: none;
+}
+footer {
+text-align: center;
+}
+
+.tag td {
+            border-width: 0px;
+            font-weight: bold;
+            padding-top: 7px;
+            padding-bottom: 7px;
+        }
+	</style>
+</head>
+<body>
+<h1>{title}<br/> {title2} </h1>
+
+{table}
+
+</body>
+<footer><p></p>Changelog  {title}<br/> {title2} </footer>
+</html>

--- a/src/main/resources/html/css/gitlog.css
+++ b/src/main/resources/html/css/gitlog.css
@@ -1,0 +1,61 @@
+.changelog{
+
+    width:auto;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+		table {
+border:3px solid #000000;
+border-collapse:collapse;
+width:90%;
+margin:auto;
+}
+thead, tfoot {
+background-color:#4D4D4D;
+border:1px solid #4D4D4D;
+}
+tbody {
+background-color:#FFFFFF;
+border:1px solid #333;
+}
+th {
+font-family:monospace;
+border:1px dotted #333;
+padding:5px;
+color: white;
+width:auto;
+}
+td {
+font-family:sans-serif;
+font-size:80%;
+border:1px solid #333;
+padding:5px;
+text-align:left;
+}
+caption {
+font-family:sans-serif;
+}
+
+		details {
+	display:block; /* Pour les navigateurs n'implémentant pas <details> et <summary> */
+}
+summary {
+	display:block; /* Pour les navigateurs n'implémentant pas <details> et <summary> */
+	background:#FFFFFF;
+	color: #663300 ;
+	
+	cursor:pointer;font-weight:bold;
+}
+h1 {
+    font-family: Times New Roman, Times, serif;
+    font-style: normal;
+    font-weight: bold;
+    font-size: 14pt;
+    color: #000;
+    text-align: center;
+    border-style: none;
+}
+footer {
+text-align: center;
+}

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -10,6 +10,7 @@ Sample output
 
 Using the default plugin parameters, the changelog for this project looks like the following:
 
+[HTML Full](http://danielflower.github.com/maven-gitlog-plugin/samples/changelogfull.html) /
 [HTML example](http://danielflower.github.com/maven-gitlog-plugin/samples/changelog.html) /
 [Markdown example](http://danielflower.github.com/maven-gitlog-plugin/samples/changelog.md) /
 [Asciidoc example](http://danielflower.github.com/maven-gitlog-plugin/samples/changelog.adoc) /

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -80,6 +80,34 @@ The following example shows all the possible configuration values with default v
 		</dependencies>
 	</plugin>
 
+The following example shows only the commits of the last release (with the option includeOnlyCommitsAfterRelease)  and install the report in the local repository of Maven (with the the goal install).
+
+	<plugin>
+						<groupId>com.github.danielflower.mavenplugins</groupId>
+						<artifactId>gitlog-maven-plugin</artifactId>
+						<version>2.0.0-SNAPSHOT</version>
+						<inherited>false</inherited>
+						<configuration>
+							<reportTitle>Projet : ${project.groupId}:${project.artifactId} Version : ${project.version}</reportTitle>
+							<verbose>true</verbose>
+							<outputDirectory>${project.build.directory}/docs</outputDirectory>
+							<generateSimpleHTMLChangeLog>true</generateSimpleHTMLChangeLog>
+							<simpleHTMLChangeLogFilename>simplechangelog.html</simpleHTMLChangeLogFilename>
+							<includeOnlyCommitsAfterRelease>false</includeOnlyCommitsAfterRelease>
+							<fullGitMessage>true</fullGitMessage>
+							<dateFormat>yyyy-MM-dd HH:mm:ss</dateFormat>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>generate</goal>
+									<goal>install</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					
+
 Including the changelog in your Maven assembly
 ----------------------------------------------
 

--- a/src/site/resources/samples/changelogfull.html
+++ b/src/site/resources/samples/changelogfull.html
@@ -1,0 +1,367 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- saved from url=(0048)http://openweb.eu.org/IMG/article90/annexe2.html -->
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<meta charset="UTF-8"/>
+<link rel="stylesheet" type="text/css" href="css/gitlog.css"/>
+<style type="text/css">
+
+
+.changelog{
+
+    width:auto;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+		table {
+border:3px solid #000000;
+border-collapse:collapse;
+width:90%;
+margin:auto;
+}
+thead, tfoot {
+background-color:#4D4D4D;
+border:1px solid #4D4D4D;
+}
+tbody {
+background-color:#FFFFFF;
+border:1px solid #333;
+}
+th {
+font-family:monospace;
+border:1px dotted #333;
+padding:5px;
+color: white;
+width:auto;
+}
+td {
+font-family:sans-serif;
+font-size:80%;
+border:1px solid #333;
+padding:5px;
+text-align:left;
+}
+caption {
+font-family:sans-serif;
+}
+
+		details {
+	display:block;  
+}
+summary {
+	display:block; 
+	background:#FFFFFF;
+	color: #663300 ;
+	
+	cursor:pointer;font-weight:bold;
+}
+h1 {
+    font-family: Times New Roman, Times, serif;
+    font-style: normal;
+    font-weight: bold;
+    font-size: 14pt;
+    color: #000;
+    text-align: center;
+    border-style: none;
+}
+footer {
+text-align: center;
+}
+
+.tag td {
+            border-width: 0px;
+            font-weight: bold;
+            padding-top: 7px;
+            padding-bottom: 7px;
+        }
+	</style>
+</head>
+<body>
+<h1>Projet : com.github.danielflower.mavenplugins:gitlog-maven-plugin <br/> Version : 2.0.0-SNAPSHOT </h1>
+
+	<table >
+		<tbody>
+<thead>		<tr><th>Date</th><th>Author</th><th>Message</th><th>Files</th></tr></thead>
+		<tr><td class="date">2017-02-27 10:44:00</td><td><span class="committer">EDENE Moh</span></td><td>change version to 2.0.0-SNAPSHOT</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2017-02-22 10:28:47</td><td><span class="committer">EDENE Moh</span></td><td>change name of goal</td><td>[RENAME src/main/java/com/github/danielflower/mavenplugins/gitlog/DeployReportMojo.java->src/main/java/com/github/danielflower/mavenplugins/gitlog/InstallReportMojo.java]</td></tr>
+		<tr><td class="date">2017-02-22 10:27:35</td><td><span class="committer">EDENE Moh</span></td><td>change name of goal</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2017-02-17 15:25:20</td><td><span class="committer">EDENE Moh</span></td><td>[evol] Add a new report type FullHTML + Add the parameter includeOnlyCommitsAfterRelease to display only the commits of the last release
+</td><td>[MODIFY pom.xml]</br><details> <summary>Show all files: </summary>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/ConfigProperties.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/DeployReportMojo.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Generator.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/DuplicateCommitMessageFilter.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/ChangeLogRenderer.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/FileRenderer.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/FullHtmlRenderer.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/MavenLoggerRenderer.java]</br>[ADD src/main/resources/configuration.properties]</br>[ADD src/main/resources/html/FullHtmlTemplate.html]</br>[ADD src/main/resources/html/css/gitlog.css]</br></details></td></tr>
+		<tr class="tag"><td colspan="4">Tag : gitlog-maven-plugin-1.13.3</td></tr>
+		<tr><td class="date">2016-09-24 08:40:27</td><td><span class="committer">Daniel Flower</span></td><td>Bumped release plugin version
+</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2016-09-22 16:33:27</td><td><span class="committer">Olivier Revial</span></td><td>Add Asciidoc converter support
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br><details> <summary>Show all files: </summary>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/AsciidocLinkConverter.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/AsciidocRenderer.java]</br>[MODIFY src/site/markdown/index.md]</br>[MODIFY src/site/markdown/usage.md.vm]</br>[ADD src/site/resources/samples/changelog.adoc]</br>[MODIFY src/site/site.xml]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br>[ADD src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/AsciidocLinkConverterTest.java]</br></details></td></tr>
+		<tr class="tag"><td colspan="4">Tag : gitlog-maven-plugin-1.13.0</td></tr>
+		<tr class="tag"><td colspan="4">Tag : gitlog-maven-plugin-1.13.1</td></tr>
+		<tr class="tag"><td colspan="4">Tag : gitlog-maven-plugin-1.13.2</td></tr>
+		<tr><td class="date">2016-03-20 14:12:39</td><td><span class="committer">Daniel Flower</span></td><td>Bumped minor version
+</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2016-03-20 14:11:30</td><td><span class="committer">Daniel Flower</span></td><td>Updated release plugin version
+</td><td>[MODIFY pom.xml]</td></tr>
+		<tr class="tag"><td colspan="4">Tag : gitlog-maven-plugin-1.12.4</td></tr>
+		<tr><td class="date">2016-03-16 13:26:41</td><td><span class="committer">Oliver Weiler</span></td><td>Remove unnecessay check
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/PathCommitFilter.java]</td></tr>
+		<tr><td class="date">2016-03-15 12:03:00</td><td><span class="committer">Oliver Weiler</span></td><td>Update PathCommitFilter.java</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/PathCommitFilter.java]</td></tr>
+		<tr><td class="date">2016-03-15 10:25:22</td><td><span class="committer">helpermethod</span></td><td>Add support for specifiying absolute paths
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/PathCommitFilter.java]</td></tr>
+		<tr><td class="date">2016-03-15 09:17:43</td><td><span class="committer">helpermethod</span></td><td>Extract path filtering login into PathCommitFilter to introduce as few changes a possible
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Generator.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/PathCommitFilter.java]</br></details></td></tr>
+		<tr><td class="date">2016-03-14 13:48:00</td><td><span class="committer">helpermethod</span></td><td>Add path option to filter out commits only related to files found under this path
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Generator.java]</br></details></td></tr>
+		<tr class="tag"><td colspan="4">Tag : gitlog-maven-plugin-1.12.1</td></tr>
+		<tr class="tag"><td colspan="4">Tag : gitlog-maven-plugin-1.12.2</td></tr>
+		<tr class="tag"><td colspan="4">Tag : gitlog-maven-plugin-1.12.3</td></tr>
+		<tr><td class="date">2015-10-26 17:14:57</td><td><span class="committer">dziesio</span></td><td>Implement filtering commit messages basing on regexp
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br><details> <summary>Show all files: </summary>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/RegexpFilter.java]</br>[MODIFY src/site/markdown/usage.md.vm]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br></details></td></tr>
+		<tr class="tag"><td colspan="4">Tag : gitlog-maven-plugin-1.12.0</td></tr>
+		<tr><td class="date">2015-07-20 14:12:30</td><td><span class="committer">Hrotkó Gábor</span></td><td>add "Gitlog report at site generation" section to the usage</td><td>[MODIFY src/site/markdown/usage.md.vm]</td></tr>
+		<tr><td class="date">2015-07-15 22:23:28</td><td><span class="committer">hrotkog</span></td><td>reporintg without aggregate</td><td>[MODIFY pom.xml]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateReport.java]</br></details></td></tr>
+		<tr class="tag"><td colspan="4">Tag : gitlog-maven-plugin-1.11.0</td></tr>
+		<tr><td class="date">2015-07-05 14:13:36</td><td><span class="committer">Daniel Flower</span></td><td>Upgraded release plugin version
+</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2015-07-05 14:07:22</td><td><span class="committer">Daniel Flower</span></td><td>Fixing merge conflicts
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Generator.java]</td></tr>
+		<tr><td class="date">2015-06-28 22:28:10</td><td><span class="committer">hrotkog</span></td><td>add note about possible reporting plugin conflict</td><td>[MODIFY README.md]</td></tr>
+		<tr><td class="date">2015-06-28 22:22:36</td><td><span class="committer">hrotkog</span></td><td>revert default filenames</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</td></tr>
+		<tr><td class="date">2015-06-24 14:57:27</td><td><span class="committer">hrotkog</span></td><td>able to test custom git dir</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Generator.java]</br><details> <summary>Show all files: </summary>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br></details></td></tr>
+		<tr><td class="date">2015-06-24 14:52:22</td><td><span class="committer">hrotkog</span></td><td>can be used as a reporting plugin</td><td>[MODIFY README.md]</br><details> <summary>Show all files: </summary>[MODIFY pom.xml]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/ShowMojo.java]</br></details></td></tr>
+		<tr><td class="date">2015-06-16 20:25:26</td><td><span class="committer">Grzegorz Poznachowski</span></td><td>Change HTML format style
+
+Modified css style to made html format more concise. Tweak, when using full git commit message, to make it look more readible.
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/SimpleHtmlRenderer.java]</br><details> <summary>Show all files: </summary>[MODIFY src/main/resources/html/SimpleHtmlTemplate.html]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br></details></td></tr>
+		<tr class="tag"><td colspan="4">Tag : gitlog-maven-plugin-1.10.1</td></tr>
+		<tr><td class="date">2015-05-30 18:27:23</td><td><span class="committer">Grzegorz Poznachowski</span></td><td>Exclude commiters sample configuration added to site usage file
+</td><td>[MODIFY src/site/markdown/usage.md.vm]</td></tr>
+		<tr><td class="date">2015-05-28 01:25:45</td><td><span class="committer">Grzegorz Poznachowski</span></td><td>Enable to filter commits by a commiter name
+
+Rationale: maven-jgitflow-plugin in contrary to maven-release-plugin does not provide any marker in the commit message.
+It's not uncommon to have an artificial user handle project building and releasing (i.e. 'jenkins'). With this change, I can easily
+filter commit messages by user name.
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br><details> <summary>Show all files: </summary>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/CommiterFilter.java]</br></details></td></tr>
+		<tr class="tag"><td colspan="4">Tag : gitlog-maven-plugin-1.10.0</td></tr>
+		<tr><td class="date">2015-03-28 13:58:10</td><td><span class="committer">Daniel Flower</span></td><td>Fixing javadoc errors
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/CommitFilter.java]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/BugzillaIssueLinkConverter.java]</br>[MODIFY src/site/markdown/usage.md.vm]</br></details></td></tr>
+		<tr><td class="date">2015-03-28 11:09:25</td><td><span class="committer">Daniel Flower</span></td><td>Updated the release plugin
+</td><td>[MODIFY CONTRIBUTING.md]</br><details> <summary>Show all files: </summary>[MODIFY pom.xml]</br></details></td></tr>
+		<tr><td class="date">2015-03-28 11:07:35</td><td><span class="committer">Daniel Flower</span></td><td>Fixed formatting
+</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2015-03-24 16:31:48</td><td><span class="committer">hrotkogabor</span></td><td>Update usage.md.vm
+
+add custom bugzilla pattern example to usage</td><td>[MODIFY src/site/markdown/usage.md.vm]</td></tr>
+		<tr><td class="date">2015-03-24 16:30:42</td><td><span class="committer">hrotkogabor</span></td><td>Update usage.md.vm
+
+add buzilla to usage</td><td>[MODIFY src/site/markdown/usage.md.vm]</td></tr>
+		<tr><td class="date">2015-03-24 16:14:57</td><td><span class="committer">hrotkog</span></td><td>ability to configure the regexp pattern for bugzilla</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/BugzillaIssueLinkConverter.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/BugzillaIssueLinkConverterTest.java]</br></details></td></tr>
+		<tr><td class="date">2015-03-24 14:59:14</td><td><span class="committer">hrotkog</span></td><td>original pom.xml</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2015-03-24 14:35:15</td><td><span class="committer">hrotkog</span></td><td>maven 3.1 artifactId change, add default plugin execution</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2015-03-24 14:00:29</td><td><span class="committer">hrotkog</span></td><td>add bugzilla link converter</td><td>[MODIFY pom.xml]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/BugzillaIssueLinkConverter.java]</br>[ADD src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/BugzillaIssueLinkConverterTest.java]</br></details></td></tr>
+		<tr><td class="date">2015-03-24 11:06:12</td><td><span class="committer">hrotkog</span></td><td>maven 3.1 artifactId change, add default plugin execution</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2015-03-23 12:14:38</td><td><span class="committer">Manuel</span></td><td>Generate clean HTML</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/SimpleHtmlRenderer.java]</td></tr>
+		<tr class="tag"><td colspan="4">Tag : maven-gitlog-plugin-1.9.0</td></tr>
+		<tr class="tag"><td colspan="4">Tag : maven-gitlog-plugin-1.9.1</td></tr>
+		<tr><td class="date">2015-03-14 13:11:30</td><td><span class="committer">Daniel Flower</span></td><td>Fixed the version
+</td><td>[MODIFY pom.xml]</td></tr>
+		<tr class="tag"><td colspan="4">Tag : maven-gitlog-plugin-1.8.0.0</td></tr>
+		<tr><td class="date">2015-03-14 13:04:07</td><td><span class="committer">Daniel Flower</span></td><td>Fixed SCM typo
+</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2015-03-14 13:02:29</td><td><span class="committer">Daniel Flower</span></td><td>Fixed SCM typo
+</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2015-03-14 12:59:04</td><td><span class="committer">Daniel Flower</span></td><td>Updated documentation
+</td><td>[ADD CONTRIBUTING.md]</br><details> <summary>Show all files: </summary>[MODIFY README.md]</br></details></td></tr>
+		<tr><td class="date">2015-03-14 12:46:49</td><td><span class="committer">Daniel Flower</span></td><td>Updated all the plugins, changed to annotation-based declarations on the mojo, and created a Maven site
+</td><td>[ADD .editorconfig]</br><details> <summary>Show all files: </summary>[MODIFY pom.xml]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/ShowMojo.java]</br>[ADD src/site/markdown/index.md]</br>[ADD src/site/markdown/usage.md.vm]</br>[ADD src/site/resources/samples/changelog.html]</br>[ADD src/site/resources/samples/changelog.json]</br>[ADD src/site/resources/samples/changelog.md]</br>[ADD src/site/resources/samples/changelog.txt]</br>[ADD src/site/resources/samples/changelogFull.txt]</br>[ADD src/site/resources/samples/changelogtable.html]</br>[ADD src/site/site.xml]</br></details></td></tr>
+		<tr><td class="date">2015-03-12 13:54:01</td><td><span class="committer">Kristoffer Lundén</span></td><td>Add escapes for tab "\t", backspace "\b", form feed "\f" and carriage return "\r", may create invalid JSON that can't be parsed otherwise.
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/JsonRenderer.java]</td></tr>
+		<tr class="tag"><td colspan="4">Tag : maven-gitlog-plugin-1.7.0</td></tr>
+		<tr><td class="date">2014-05-25 14:53:01</td><td><span class="committer">Daniel Flower</span></td><td>Updated the version in preparation of release
+</td><td>[MODIFY README.md]</br><details> <summary>Show all files: </summary>[MODIFY pom.xml]</br></details></td></tr>
+		<tr><td class="date">2014-04-25 22:54:08</td><td><span class="committer">Keegan Roth</span></td><td>add json file renderer
+</td><td>[MODIFY README.md]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/JsonRenderer.java]</br>[ADD src/main/resources/json/JsonItemTemplate.html]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br></details></td></tr>
+		<tr><td class="date">2014-04-25 21:57:28</td><td><span class="committer">Keegan Roth</span></td><td>refactor resource loading into method in parent for re-use
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/FileRenderer.java]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/SimpleHtmlRenderer.java]</br></details></td></tr>
+		<tr><td class="date">2014-04-25 21:28:31</td><td><span class="committer">Keegan Roth</span></td><td>remove resource leak warning in FileRenderer.convertStreamToString()
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/FileRenderer.java]</td></tr>
+		<tr><td class="date">2014-04-25 21:27:11</td><td><span class="committer">Keegan Roth</span></td><td>move convertStreamToString() to parent class for re-use
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/FileRenderer.java]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/SimpleHtmlRenderer.java]</br></details></td></tr>
+		<tr><td class="date">2014-04-10 16:11:18</td><td><span class="committer">Daniel Flower</span></td><td>Updated version to use in readme
+</td><td>[MODIFY README.md]</td></tr>
+		<tr class="tag"><td colspan="4">Tag : maven-gitlog-plugin-1.6.0</td></tr>
+		<tr><td class="date">2014-04-10 16:00:15</td><td><span class="committer">Daniel Flower</span></td><td>Bumping minor version for new feature
+</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2014-04-07 17:46:59</td><td><span class="committer">Ivan Martinez-Ortiz</span></td><td>Include example of how to use an artifact that contains additional filters
+</td><td>[MODIFY README.md]</td></tr>
+		<tr><td class="date">2014-04-07 17:43:13</td><td><span class="committer">Ivan Martinez-Ortiz</span></td><td>Include example of how to override includeCommitsAfter parameter.
+</td><td>[MODIFY README.md]</td></tr>
+		<tr><td class="date">2014-03-31 15:26:10</td><td><span class="committer">Ivan Martinez-Ortiz</span></td><td>Add showCommitsAfter parameter to include in the changelog commits only with a timestamp after the provided parameter value.
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Generator.java]</br></details></td></tr>
+		<tr><td class="date">2014-03-20 23:25:07</td><td><span class="committer">Ivan Martinez-Ortiz</span></td><td>Add SPI loading mechanism for CommitFilters.
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Defaults.java]</td></tr>
+		<tr class="tag"><td colspan="4">Tag : maven-gitlog-plugin-1.5.2</td></tr>
+		<tr><td class="date">2013-10-21 16:30:31</td><td><span class="committer">Daniel Flower</span></td><td>Bumping readme version in anticipation of next release
+</td><td>[MODIFY README.md]</td></tr>
+		<tr class="tag"><td colspan="4">Tag : maven-gitlog-plugin-1.5.1</td></tr>
+		<tr><td class="date">2013-10-21 16:05:20</td><td><span class="committer">Daniel Flower</span></td><td>Bumped version in readme in anticipation of upcoming release
+</td><td>[MODIFY README.md]</td></tr>
+		<tr><td class="date">2013-10-20 16:39:38</td><td><span class="committer">Artem Koshelev</span></td><td>bump eclipse.jgit version
+</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2013-10-20 12:16:10</td><td><span class="committer">Artem Koshelev</span></td><td>update readme
+</td><td>[MODIFY README.md]</td></tr>
+		<tr><td class="date">2013-10-20 12:08:44</td><td><span class="committer">Artem Koshelev</span></td><td>add hamcrest dependency
+</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2013-10-20 11:48:07</td><td><span class="committer">Artem Koshelev</span></td><td>fix - create default date format
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/Formatter.java]</td></tr>
+		<tr><td class="date">2013-10-20 11:42:32</td><td><span class="committer">Artem Koshelev</span></td><td>provide ability to setup date format in Formatter
+add tests for Formatter
+bump up junit version to 4.11
+use junit4 assertions in all tests
+</td><td>[MODIFY pom.xml]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/Formatter.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/GitHubIssueLinkConverter.java]</br>[ADD src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/FormatterTest.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/GitHubIssueLinkConverterTest.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/JiraIssueLinkConverterTest.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/MarkdownLinkConverterTest.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/MarkdownRendererTest.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/NullMessageConverterTest.java]</br></details></td></tr>
+		<tr><td class="date">2013-10-19 13:47:17</td><td><span class="committer">Artem Koshelev</span></td><td>move hardcoded strings to constants
+</td><td>[MODIFY .gitignore]</br><details> <summary>Show all files: </summary>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br></details></td></tr>
+		<tr><td class="date">2013-01-12 05:59:52</td><td><span class="committer">Daniel Flower</span></td><td>Removing intellij files from maven repo. Better to be IDE agnostic.
+</td><td>[MODIFY .gitignore]</br><details> <summary>Show all files: </summary>[DELETE .idea/.name]</br>[DELETE .idea/ant.xml]</br>[DELETE .idea/compiler.xml]</br>[DELETE .idea/encodings.xml]</br>[DELETE .idea/inspectionProfiles/Project_Default.xml]</br>[DELETE .idea/inspectionProfiles/profiles_settings.xml]</br>[DELETE .idea/libraries/Maven__com_madgag_org_eclipse_jgit_1_0_99_0_2_UNOFFICIAL_ROBERTO_RELEASE.xml]</br>[DELETE .idea/libraries/Maven__junit_junit_4_8_2.xml]</br>[DELETE .idea/libraries/Maven__org_apache_commons_commons_lang3_3_0_1.xml]</br>[DELETE .idea/libraries/Maven__org_apache_maven_maven_plugin_api_2_0.xml]</br>[DELETE .idea/misc.xml]</br>[DELETE .idea/modules.xml]</br>[DELETE .idea/scopes/scope_settings.xml]</br>[DELETE .idea/uiDesigner.xml]</br>[DELETE .idea/vcs.xml]</br>[MODIFY README.md]</br>[DELETE maven-gitlog-plugin.iml]</br></details></td></tr>
+		<tr><td class="date">2013-01-12 05:53:01</td><td><span class="committer">Daniel Flower</span></td><td>Fixed typo in markdown link... getting there....
+</td><td>[MODIFY README.md]</td></tr>
+		<tr><td class="date">2013-01-12 05:52:01</td><td><span class="committer">Daniel Flower</span></td><td>Updated plugin verison to use in the readme to 1.5.0 which is the first version to support markdown generation.
+</td><td>[MODIFY README.md]</br><details> <summary>Show all files: </summary>[MODIFY maven-gitlog-plugin.iml]</br></details></td></tr>
+		<tr class="tag"><td colspan="4">Tag : maven-gitlog-plugin-1.5.0</td></tr>
+		<tr><td class="date">2013-01-12 05:41:18</td><td><span class="committer">Daniel Flower</span></td><td>Added link to markdown sample in the readme
+</td><td>[MODIFY README.md]</br><details> <summary>Show all files: </summary>[MODIFY maven-gitlog-plugin.iml]</br></details></td></tr>
+		<tr><td class="date">2013-01-12 05:35:26</td><td><span class="committer">Daniel Flower</span></td><td>Creating markdown sample
+</td><td>[MODIFY README.md]</td></tr>
+		<tr><td class="date">2013-01-12 05:31:10</td><td><span class="committer">Daniel Flower</span></td><td>Adding travis-ci build status to readme
+</td><td>[MODIFY README.md]</td></tr>
+		<tr><td class="date">2013-01-12 05:24:06</td><td><span class="committer">Daniel Flower</span></td><td>Adding travis-ci build
+</td><td>[MODIFY .idea/compiler.xml]</br><details> <summary>Show all files: </summary>[MODIFY .idea/encodings.xml]</br>[ADD .travis.yml]</br>[MODIFY maven-gitlog-plugin.iml]</br></details></td></tr>
+		<tr><td class="date">2013-01-06 22:07:48</td><td><span class="committer">Gerd Zanker</span></td><td>Refactored code for easier testing.
+Added test cases for the markdown renderer and the markdown link
+converter.
+OPEN - task 10: Generate markdown formatted gitlog 
+https://github.com/danielflower/maven-gitlog-plugin/issues/issue/10</td><td>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/MarkdownLinkConverter.java]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/MarkdownRenderer.java]</br>[ADD src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/MarkdownLinkConverterTest.java]</br>[ADD src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/MarkdownRendererTest.java]</br></details></td></tr>
+		<tr><td class="date">2013-01-05 14:12:46</td><td><span class="committer">Gerd Zanker</span></td><td>OPEN - task 10: Generate markdown formatted gitlog 
+https://github.com/danielflower/maven-gitlog-plugin/issues/issue/10
+Implemented markdown renderer and simple tests.
+Updated readme with new available maven plugin parameters.</td><td>[MODIFY README.md]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/MarkdownRenderer.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br></details></td></tr>
+		<tr class="tag"><td colspan="4">Tag : maven-gitlog-plugin-1.4.11</td></tr>
+		<tr><td class="date">2012-03-17 07:33:55</td><td><span class="committer">Daniel Flower</span></td><td>Updated maven version in docs
+</td><td>[MODIFY README.md]</td></tr>
+		<tr class="tag"><td colspan="4">Tag : maven-gitlog-plugin-1.4.10</td></tr>
+		<tr><td class="date">2012-03-17 07:06:40</td><td><span class="committer">Daniel Flower</span></td><td>Updated maven version in readme
+</td><td>[MODIFY README.md]</td></tr>
+		<tr><td class="date">2012-03-17 07:02:48</td><td><span class="committer">Daniel Flower</span></td><td>Random intellij updates
+</td><td>[MODIFY .idea/misc.xml]</br><details> <summary>Show all files: </summary>[MODIFY maven-gitlog-plugin.iml]</br></details></td></tr>
+		<tr><td class="date">2012-03-17 07:00:20</td><td><span class="committer">Daniel Flower</span></td><td>Random intellij updates
+</td><td>[MODIFY maven-gitlog-plugin.iml]</td></tr>
+		<tr><td class="date">2012-03-17 06:58:19</td><td><span class="committer">Daniel Flower</span></td><td>Random intellij updates
+</td><td>[MODIFY .idea/misc.xml]</br><details> <summary>Show all files: </summary>[ADD .idea/scopes/scope_settings.xml]</br>[MODIFY maven-gitlog-plugin.iml]</br></details></td></tr>
+		<tr><td class="date">2012-03-15 01:21:28</td><td><span class="committer">James Rawlings</span></td><td>Added property to configure use of full git message
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/PlainTextRenderer.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/SimpleHtmlRenderer.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br></details></td></tr>
+		<tr class="tag"><td colspan="4">Tag : maven-gitlog-plugin-1.4.9</td></tr>
+		<tr><td class="date">2011-09-21 15:56:28</td><td><span class="committer">Daniel Flower</span></td><td>Allow generation of table-only HTML reports. Closes <a href="https://github.com/danielflower/maven-gitlog-plugin/issues/7">#7</a>
+</td><td>[MODIFY README.md]</br><details> <summary>Show all files: </summary>[MODIFY maven-gitlog-plugin.iml]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/SimpleHtmlRenderer.java]</br>[MODIFY src/main/resources/html/SimpleHtmlTemplate.html]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br></details></td></tr>
+		<tr class="tag"><td colspan="4">Tag : maven-gitlog-plugin-1.4.8</td></tr>
+		<tr><td class="date">2011-09-19 16:17:47</td><td><span class="committer">Daniel Flower</span></td><td>Added links to example reports
+</td><td>[MODIFY README.md]</td></tr>
+		<tr><td class="date">2011-09-19 16:15:37</td><td><span class="committer">Daniel Flower</span></td><td>Added links to example reports
+</td><td>[MODIFY README.md]</br><details> <summary>Show all files: </summary>[MODIFY maven-gitlog-plugin.iml]</br></details></td></tr>
+		<tr class="tag"><td colspan="4">Tag : maven-gitlog-plugin-1.4.7</td></tr>
+		<tr><td class="date">2011-09-19 15:17:29</td><td><span class="committer">Daniel Flower</span></td><td>Preparing for initial release to OSS repository
+</td><td>[MODIFY README.md]</br><details> <summary>Show all files: </summary>[MODIFY pom.xml]</br></details></td></tr>
+		<tr><td class="date">2011-09-18 11:01:05</td><td><span class="committer">Daniel Flower</span></td><td><a href="https://github.com/danielflower/maven-gitlog-plugin/issues/3">#3</a> Adding support for issue management tools. Updated documentation. Closes <a href="https://github.com/danielflower/maven-gitlog-plugin/issues/3">#3</a>
+</td><td>[MODIFY README.md]</td></tr>
+		<tr><td class="date">2011-09-18 10:54:22</td><td><span class="committer">Daniel Flower</span></td><td><a href="https://github.com/danielflower/maven-gitlog-plugin/issues/3">#3</a> Adding support for issue management tools
+</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2011-09-18 10:52:47</td><td><span class="committer">Daniel Flower</span></td><td><a href="https://github.com/danielflower/maven-gitlog-plugin/issues/3">#3</a> Adding support for issue management tools and added config as described in <a href="https://github.com/danielflower/maven-gitlog-plugin/issues/4">gh-4</a> (a.k.a <a href="https://github.com/danielflower/maven-gitlog-plugin/issues/4">GH-4</a>/<a href="https://github.com/danielflower/maven-gitlog-plugin/issues/4">#4</a>)
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/GitHubIssueLinkConverter.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/GitHubIssueLinkConverterTest.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-18 10:48:14</td><td><span class="committer">Daniel Flower</span></td><td><a href="https://github.com/danielflower/maven-gitlog-plugin/issues/3">#3</a> Adding support for issue management tools
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/JiraIssueLinkConverter.java]</br><details> <summary>Show all files: </summary>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/GitHubIssueLinkConverterTest.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/JiraIssueLinkConverterTest.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-18 10:38:16</td><td><span class="committer">Daniel Flower</span></td><td><a href="https://github.com/danielflower/maven-gitlog-plugin/issues/3">#3</a> Adding support for issue management tools
+</td><td>[MODIFY pom.xml]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/GitHubIssueLinkConverter.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/JiraIssueLinkConverter.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/MessageConverter.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/NullMessageConverter.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/SimpleHtmlRenderer.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br>[ADD src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/GitHubIssueLinkConverterTest.java]</br>[ADD src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/JiraIssueLinkConverterTest.java]</br>[ADD src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/NullMessageConverterTest.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-18 09:17:45</td><td><span class="committer">Daniel Flower</span></td><td>Added author to plaintext renderer
+</td><td>[MODIFY README.md]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/PlainTextRenderer.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-18 08:50:07</td><td><span class="committer">Daniel Flower</span></td><td><a href="https://github.com/danielflower/maven-gitlog-plugin/issues/3">#3</a> Fix whitespace issues in HTML
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/SimpleHtmlRenderer.java]</br><details> <summary>Show all files: </summary>[MODIFY src/main/resources/html/SimpleHtmlTemplate.html]</br></details></td></tr>
+		<tr><td class="date">2011-09-18 08:36:21</td><td><span class="committer">Daniel Flower</span></td><td><a href="https://github.com/danielflower/maven-gitlog-plugin/issues/3">#3</a> The HTML renderer should HTML-encode tags like <this>, or < or > signs, or & => &amp;, and also " => &quot; etc
+</td><td>[ADD .idea/libraries/Maven__org_apache_commons_commons_lang3_3_0_1.xml]</br><details> <summary>Show all files: </summary>[MODIFY maven-gitlog-plugin.iml]</br>[MODIFY pom.xml]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/SimpleHtmlRenderer.java]</br></details></td></tr>
+		<tr class="tag"><td colspan="4">Tag : maven-gitlog-plugin-1.4.5</td></tr>
+		<tr><td class="date">2011-09-18 08:12:09</td><td><span class="committer">Daniel Flower</span></td><td>Added instructions on how to run the show goal
+</td><td>[MODIFY README.md]</td></tr>
+		<tr><td class="date">2011-09-18 08:06:08</td><td><span class="committer">Daniel Flower</span></td><td>Rearranged packages
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Defaults.java]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Generator.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/ShowMojo.java]</br>[RENAME src/main/java/com/github/danielflower/mavenplugins/gitlog/CommitFilter.java->src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/CommitFilter.java]</br>[RENAME src/main/java/com/github/danielflower/mavenplugins/gitlog/DuplicateCommitMessageFilter.java->src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/DuplicateCommitMessageFilter.java]</br>[RENAME src/main/java/com/github/danielflower/mavenplugins/gitlog/MavenReleasePluginMessageFilter.java->src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/MavenReleasePluginMessageFilter.java]</br>[RENAME src/main/java/com/github/danielflower/mavenplugins/gitlog/MergeCommitFilter.java->src/main/java/com/github/danielflower/mavenplugins/gitlog/filters/MergeCommitFilter.java]</br>[RENAME src/main/java/com/github/danielflower/mavenplugins/gitlog/ChangeLogRenderer.java->src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/ChangeLogRenderer.java]</br>[RENAME src/main/java/com/github/danielflower/mavenplugins/gitlog/FileRenderer.java->src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/FileRenderer.java]</br>[RENAME src/main/java/com/github/danielflower/mavenplugins/gitlog/Formatter.java->src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/Formatter.java]</br>[RENAME src/main/java/com/github/danielflower/mavenplugins/gitlog/MavenLoggerRenderer.java->src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/MavenLoggerRenderer.java]</br>[RENAME src/main/java/com/github/danielflower/mavenplugins/gitlog/PlainTextRenderer.java->src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/PlainTextRenderer.java]</br>[RENAME src/main/java/com/github/danielflower/mavenplugins/gitlog/SimpleHtmlRenderer.java->src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/SimpleHtmlRenderer.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-18 07:58:03</td><td><span class="committer">Daniel Flower</span></td><td>Filter out merge commits from the changelog.  Closes <a href="https://github.com/danielflower/maven-gitlog-plugin/issues/6">#6</a>
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Defaults.java]</br><details> <summary>Show all files: </summary>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/MergeCommitFilter.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-18 07:49:22</td><td><span class="committer">Daniel Flower</span></td><td>Fixed comment in unit test (master)
+</td><td>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</td></tr>
+		<tr><td class="date">2011-09-18 07:47:39</td><td><span class="committer">Daniel Flower</span></td><td>Cleaned up HTML
+</td><td>[MODIFY src/main/resources/html/SimpleHtmlTemplate.html]</td></tr>
+		<tr><td class="date">2011-09-18 07:45:41</td><td><span class="committer">Daniel Flower</span></td><td>Preparing for release
+</td><td>[MODIFY maven-gitlog-plugin.iml]</br><details> <summary>Show all files: </summary>[MODIFY pom.xml]</br></details></td></tr>
+		<tr><td class="date">2011-09-18 06:09:54</td><td><span class="committer">Daniel Flower</span></td><td>Fixed groupid and added new show goal
+</td><td>[MODIFY maven-gitlog-plugin.iml]</br><details> <summary>Show all files: </summary>[MODIFY pom.xml]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/ShowMojo.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-17 18:21:12</td><td><span class="committer">Daniel Flower</span></td><td><a href="https://github.com/danielflower/maven-gitlog-plugin/issues/4">#4</a> Fixed name of README file
+</td><td>[RENAME README.me->README.md]</td></tr>
+		<tr><td class="date">2011-09-17 18:19:57</td><td><span class="committer">Daniel Flower</span></td><td><a href="https://github.com/danielflower/maven-gitlog-plugin/issues/4">#4</a> Allow configuration of renderers
+</td><td>[DELETE README]</br><details> <summary>Show all files: </summary>[ADD README.me]</br>[MODIFY maven-gitlog-plugin.iml]</br>[MODIFY pom.xml]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/ChangeLogRenderer.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Generator.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/MavenLoggerRenderer.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/PlainTextRenderer.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/SimpleHtmlRenderer.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-17 16:21:36</td><td><span class="committer">Daniel Flower</span></td><td><a href="https://github.com/danielflower/maven-gitlog-plugin/issues/3">#3</a> Added Simple HTML formatter
+</td><td>[MODIFY maven-gitlog-plugin.iml]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/ChangeLogRenderer.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/FileRenderer.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Generator.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/MavenLoggerRenderer.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/PlainTextRenderer.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/SimpleHtmlRenderer.java]</br>[ADD src/main/resources/html/SimpleHtmlTemplate.html]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-17 15:23:30</td><td><span class="committer">Daniel Flower</span></td><td>Cleaned up access modifiers
+</td><td>[MODIFY maven-gitlog-plugin.iml]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/CommitFilter.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Defaults.java]</br>[RENAME src/main/java/com/github/danielflower/mavenplugins/gitlog/DuplicateCommitFilter.java->src/main/java/com/github/danielflower/mavenplugins/gitlog/DuplicateCommitMessageFilter.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/MavenReleasePluginMessageFilter.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/NoGitRepositoryException.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-17 12:17:16</td><td><span class="committer">Daniel Flower</span></td><td><a href="https://github.com/danielflower/maven-gitlog-plugin/issues/4">gh-4</a> Fixed bug in filtering when there are multiple renderers
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</td></tr>
+		<tr><td class="date">2011-09-17 12:06:22</td><td><span class="committer">Daniel Flower</span></td><td><a href="https://github.com/danielflower/maven-gitlog-plugin/issues/4">gh-4</a> Fixed bug in filtering when there are multiple renderers
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Generator.java]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/PlainTextRenderer.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-17 11:48:10</td><td><span class="committer">Daniel Flower</span></td><td><a href="https://github.com/danielflower/maven-gitlog-plugin/issues/4">GH-4</a> Improve the error reporting for when no git repository is found
+</td><td>[MODIFY .idea/.name]</br><details> <summary>Show all files: </summary>[MODIFY pom.xml]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Generator.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/NoGitRepositoryException.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-17 11:30:35</td><td><span class="committer">Daniel Flower</span></td><td><a href="https://github.com/danielflower/maven-gitlog-plugin/issues/4">#4</a> Set up the GenerateMojo to execute the plugin
+</td><td>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/Defaults.java]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-17 11:15:12</td><td><span class="committer">Daniel Flower</span></td><td>Fixed issue management node
+</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2011-09-17 11:06:07</td><td><span class="committer">Daniel Flower</span></td><td>Do not show maven release plugin messages.  Closes <a href="https://github.com/danielflower/maven-gitlog-plugin/issues/1">GH-1</a>
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/MavenLoggerRenderer.java]</br><details> <summary>Show all files: </summary>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/MavenReleasePluginMessageFilter.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-17 11:00:46</td><td><span class="committer">Daniel Flower</span></td><td>Do not show duplicate commit messages.  Closes <a href="https://github.com/danielflower/maven-gitlog-plugin/issues/2">#2</a>
+</td><td>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/CommitFilter.java]</br><details> <summary>Show all files: </summary>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/DuplicateCommitFilter.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Generator.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-17 10:47:53</td><td><span class="committer">Daniel Flower</span></td><td>Fixed some project setup issues
+</td><td>[MODIFY .idea/compiler.xml]</br><details> <summary>Show all files: </summary>[DELETE .idea/libraries/Maven__com_jcraft_jsch_0_1_44_1.xml]</br>[MODIFY maven-gitlog-plugin.iml]</br>[MODIFY pom.xml]</br></details></td></tr>
+		<tr class="tag"><td colspan="4">Tag : maven-gitlog-plugin-1.2</td></tr>
+		<tr><td class="date">2011-09-17 10:09:37</td><td><span class="committer">Daniel Flower</span></td><td>Temporarily adding local repository for deployments
+</td><td>[MODIFY maven-gitlog-plugin.iml]</br><details> <summary>Show all files: </summary>[MODIFY pom.xml]</br></details></td></tr>
+		<tr><td class="date">2011-09-17 10:08:19</td><td><span class="committer">Daniel Flower</span></td><td>Temporarily adding local repository for deployments
+</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2011-09-17 10:06:55</td><td><span class="committer">Daniel Flower</span></td><td>Temporarily adding local repository for deployments
+</td><td>[MODIFY maven-gitlog-plugin.iml]</br><details> <summary>Show all files: </summary>[MODIFY pom.xml]</br></details></td></tr>
+		<tr class="tag"><td colspan="4">Tag : maven-gitlog-plugin-1.1</td></tr>
+		<tr><td class="date">2011-09-17 09:54:53</td><td><span class="committer">Daniel Flower</span></td><td>Fixing maven release issues
+</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2011-09-17 09:53:21</td><td><span class="committer">Daniel Flower</span></td><td>Fixed github repo URLs
+</td><td>[MODIFY pom.xml]</td></tr>
+		<tr><td class="date">2011-09-17 09:50:34</td><td><span class="committer">Daniel Flower</span></td><td>Fixed github repo URLs
+</td><td>[MODIFY maven-gitlog-plugin.iml]</br><details> <summary>Show all files: </summary>[MODIFY pom.xml]</br></details></td></tr>
+		<tr><td class="date">2011-09-17 09:42:49</td><td><span class="committer">Daniel Flower</span></td><td>Got PlainText renderer working
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Formatter.java]</br><details> <summary>Show all files: </summary>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Generator.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/MavenLoggerRenderer.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/PlainTextRenderer.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-17 09:18:59</td><td><span class="committer">Daniel Flower</span></td><td>Refactored sout logger to use the maven log interface
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/Generator.java]</br><details> <summary>Show all files: </summary>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/MavenLoggerRenderer.java]</br>[DELETE src/main/java/com/github/danielflower/mavenplugins/gitlog/StandardOutputRenderer.java]</br>[MODIFY src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-17 09:03:09</td><td><span class="committer">Daniel Flower</span></td><td>Added support for reading annotated tags
+</td><td>[ADD .idea/ant.xml]</br><details> <summary>Show all files: </summary>[ADD .idea/libraries/Maven__junit_junit_4_8_2.xml]</br>[MODIFY maven-gitlog-plugin.iml]</br>[MODIFY pom.xml]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/ChangeLogRenderer.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/Formatter.java]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/Generator.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/PlainTextRenderer.java]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/StandardOutputRenderer.java]</br>[ADD src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-17 07:10:35</td><td><span class="committer">Daniel Flower</span></td><td>Renaming project
+</td><td>[ADD maven-gitlog-plugin.iml]</td></tr>
+		<tr><td class="date">2011-09-17 07:10:25</td><td><span class="committer">Daniel Flower</span></td><td>Renaming project
+</td><td>[MODIFY .idea/modules.xml]</br><details> <summary>Show all files: </summary>[DELETE git-log-maven-plugin.iml]</br></details></td></tr>
+		<tr><td class="date">2011-09-16 20:42:36</td><td><span class="committer">Daniel Flower</span></td><td>Can write the list of commits
+</td><td>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</td></tr>
+		<tr><td class="date">2011-09-16 20:31:45</td><td><span class="committer">Daniel Flower</span></td><td>Initial attempt to use jgit
+</td><td>[ADD .idea/libraries/Maven__com_jcraft_jsch_0_1_44_1.xml]</br><details> <summary>Show all files: </summary>[ADD .idea/libraries/Maven__com_madgag_org_eclipse_jgit_1_0_99_0_2_UNOFFICIAL_ROBERTO_RELEASE.xml]</br>[DELETE .idea/libraries/Maven__junit_junit_4_8_2.xml]</br>[MODIFY git-log-maven-plugin.iml]</br>[MODIFY pom.xml]</br>[MODIFY src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-16 19:38:24</td><td><span class="committer">Daniel Flower</span></td><td>Got initial mojo set up to write to a text file
+</td><td>[ADD .gitignore]</br><details> <summary>Show all files: </summary>[ADD .idea/.name]</br>[ADD .idea/compiler.xml]</br>[ADD .idea/encodings.xml]</br>[ADD .idea/inspectionProfiles/Project_Default.xml]</br>[ADD .idea/inspectionProfiles/profiles_settings.xml]</br>[ADD .idea/libraries/Maven__junit_junit_4_8_2.xml]</br>[ADD .idea/libraries/Maven__org_apache_maven_maven_plugin_api_2_0.xml]</br>[ADD .idea/misc.xml]</br>[ADD .idea/modules.xml]</br>[ADD .idea/uiDesigner.xml]</br>[ADD .idea/vcs.xml]</br>[MODIFY git-log-maven-plugin.iml]</br>[MODIFY pom.xml]</br>[ADD src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java]</br></details></td></tr>
+		<tr><td class="date">2011-09-16 18:58:33</td><td><span class="committer">Daniel Flower</span></td><td>Initial maven setup
+</td><td>[ADD git-log-maven-plugin.iml]</br><details> <summary>Show all files: </summary>[ADD pom.xml]</br></details></td></tr>
+		<tr><td class="date">2011-09-16 18:26:19</td><td><span class="committer">Daniel Flower</span></td><td>first commit
+</td><td></td></tr>
+		</tbody>
+	</table>
+
+
+</body>
+<footer><p></p>Changelog  Projet : com.github.danielflower.mavenplugins:gitlog-maven-plugin <br/> Version : 2.0.0-SNAPSHOT </footer>
+</html>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -26,7 +26,8 @@
 			<item name="Goals" href="plugin-info.html"/>
         </menu>
 		<menu name="Sample reports">
-			<item name="HTML" href="samples/changelog.html" />
+			<item name="HTML Full" href="samples/changelogfull.html" />
+		    <item name="HTML" href="samples/changelog.html" />
 			<item name="HTML table" href="samples/changelogtable.html" />
 			<item name="Markdown" href="samples/changelog.md" />
 			<item name="Asciidoc" href="samples/changelog.adoc" />


### PR DESCRIPTION
Hello Daniel,

Following our exchange [Layout report HTML : evolution #37](https://github.com/danielflower/maven-gitlog-plugin/issues/37)

- I added a new type of html report with options **generateFullHTMLChangeLog** and **fullHTMLChangeLogFilename**  :
![gitlog](https://cloud.githubusercontent.com/assets/15674407/23069394/8caaf79e-f527-11e6-8ed3-9cd3a558522b.jpg)

- I added the option **includeOnlyCommitsAfterRelease** allows to generate only the commits of the last release
-  I added the new goal **install** to install the report in the local repository of Maven.

I propose to integrate in the next version.
