### PR TITLE
added a regex-message-filter. It will take a (or more) regex and remo…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.danielflower.mavenplugins</groupId>
   <artifactId>gitlog-maven-plugin</artifactId>
-	<version>1.13-SNAPSHOT</version>
+  <version>1.13-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
   <name>Maven Git Log Plugin</name>
   <description>Generates a changelog based on commits to a git repository in text and HTML format showing the changes
-        that are included in each version. A possible use of this is to include these changelogs when packaging your
-        maven project so that you have an accurate list of commits that the current package includes.</description>
+    that are included in each version. A possible use of this is to include these changelogs when packaging your
+    maven project so that you have an accurate list of commits that the current package includes.</description>
   <url>http://github.com/danielflower/maven-gitlog-plugin</url>
   <inceptionYear>2011</inceptionYear>
   <licenses>
@@ -186,6 +186,14 @@
             <version>1.6</version>
           </dependency>
         </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
@@ -285,7 +285,11 @@ public class GenerateMojo extends AbstractMojo {
 	@Parameter(defaultValue = "Merge")
 	private String asciidocTableViewHeader2ReleaseNotes;
 
-	@Override
+
+    @Parameter(defaultValue = "")
+    private String messageRegexFilter;
+
+    @Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		getLog().info("Generating gitlog in " + outputDirectory.getAbsolutePath()
 				+ " with title " + reportTitle);
@@ -354,14 +358,14 @@ public class GenerateMojo extends AbstractMojo {
 	private List<ChangeLogRenderer> createRenderers() throws IOException {
 		ArrayList<ChangeLogRenderer> renderers = new ArrayList<ChangeLogRenderer>();
 
+        MessageConverter messageConverter = getCommitMessageConverter();
 		if (generatePlainTextChangeLog) {
-			renderers.add(new PlainTextRenderer(getLog(), outputDirectory, plainTextChangeLogFilename, fullGitMessage));
+			renderers.add(new PlainTextRenderer(getLog(), outputDirectory, plainTextChangeLogFilename, fullGitMessage, messageConverter));
 		}
 
 		if (generateSimpleHTMLChangeLog || generateHTMLTableOnlyChangeLog || generateMarkdownChangeLog ||
 				generateAsciidocChangeLog || generatAsciidocChangeLog || generateAsciidocReleaseNotes ||
 				generatAsciidocReleaseNotes) {
-			MessageConverter messageConverter = getCommitMessageConverter();
 			if (generateSimpleHTMLChangeLog) {
 				renderers.add(new SimpleHtmlRenderer(getLog(), outputDirectory, simpleHTMLChangeLogFilename, fullGitMessage, messageConverter, false));
 			}
@@ -380,7 +384,7 @@ public class GenerateMojo extends AbstractMojo {
 		}
 
 		if (generateJSONChangeLog) {
-			renderers.add(new JsonRenderer(getLog(), outputDirectory, jsonChangeLogFilename, fullGitMessage));
+			renderers.add(new JsonRenderer(getLog(), outputDirectory, jsonChangeLogFilename, fullGitMessage, messageConverter));
 		}
 
 		if (verbose) {
@@ -408,6 +412,9 @@ public class GenerateMojo extends AbstractMojo {
 		} catch (Exception ex) {
 			getLog().warn("Could not load issue management system information; no HTML links will be generated.", ex);
 		}
+		if (messageRegexFilter!=null && !messageRegexFilter.isEmpty()){
+		    converter=new RegexFilterMessageConverter(messageRegexFilter,converter);
+        }
 		if (converter == null) {
 			converter = new NullMessageConverter();
 		}

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/JsonRenderer.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/JsonRenderer.java
@@ -12,6 +12,7 @@ import org.eclipse.jgit.revwalk.RevTag;
 
 public class JsonRenderer extends FileRenderer {
 
+    private  MessageConverter messageConverter;
 	private String template;
 	protected StringBuilder json = new StringBuilder();
 	private final boolean fullGitMessage;
@@ -26,6 +27,11 @@ public class JsonRenderer extends FileRenderer {
 		this.template = loadResourceToString("/json/JsonItemTemplate.html");
 	}
 
+    public JsonRenderer(Log log, File targetFolder, String filename, boolean fullGitMessage,MessageConverter messageConverter)
+        throws IOException {
+        this(log, targetFolder, filename, fullGitMessage);
+        this.messageConverter = messageConverter;
+    }
 	@Override
 	public void renderHeader(String reportTitle) throws IOException {
 		json.append("[\n");
@@ -45,6 +51,9 @@ public class JsonRenderer extends FileRenderer {
 		} else {
 			message = commit.getShortMessage();
 		}
+		if (messageConverter!=null){
+		    message=messageConverter.formatCommitMessage(message);
+        }
 		StringBuffer tagsJson = new StringBuffer();
 		boolean firstTag = true;
 		for (RevTag tag : this.tags) {

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/PlainTextRenderer.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/PlainTextRenderer.java
@@ -11,7 +11,8 @@ import static com.github.danielflower.mavenplugins.gitlog.renderers.Formatter.NE
 
 public class PlainTextRenderer extends FileRenderer {
 
-	private boolean previousWasTag = false;
+    private MessageConverter messageConverter;
+    private boolean previousWasTag = false;
 	private final boolean fullGitMessage;
 
 	public PlainTextRenderer(Log log, File targetFolder, String filename, boolean fullGitMessage) throws IOException {
@@ -19,7 +20,13 @@ public class PlainTextRenderer extends FileRenderer {
 		this.fullGitMessage = fullGitMessage;
 	}
 
-	public void renderHeader(String reportTitle) throws IOException {
+    public PlainTextRenderer(Log log, File targetFolder, String filename, boolean fullGitMessage,MessageConverter messageConverter) throws IOException {
+        this(log, targetFolder, filename, fullGitMessage);
+        this.messageConverter = messageConverter;
+    }
+
+
+    public void renderHeader(String reportTitle) throws IOException {
 		if (reportTitle != null && reportTitle.length() > 0) {
 			writer.write(reportTitle);
 			writer.write(NEW_LINE);
@@ -43,6 +50,10 @@ public class PlainTextRenderer extends FileRenderer {
 		} else {
 			message = commit.getShortMessage();
 		}
+		if (messageConverter!=null){
+		    message=messageConverter.formatCommitMessage(message);
+        }
+
 		writer.write(Formatter.formatDateTime(commit.getCommitTime()) + "    " + message);
 		writer.write(" " + Formatter.formatCommiter(commit.getCommitterIdent()));
 		writer.write(NEW_LINE);

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/RegexFilterMessageConverter.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/RegexFilterMessageConverter.java
@@ -1,0 +1,69 @@
+package com.github.danielflower.mavenplugins.gitlog.renderers;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * message converter that will remove all test except whatever matches the regex
+ * it can apply multiple regexes (that can overlap) and pull out all matches in order
+ */
+public class RegexFilterMessageConverter implements MessageConverter {
+    private final List<Pattern> patterns;
+    private final MessageConverter converter;
+
+    /**
+     *
+     * @param messageRegexFilter a string with regex separated with &&&
+     * @param converter a converter that will be applied after this
+     */
+    public RegexFilterMessageConverter(String messageRegexFilter, /*nullable*/ MessageConverter converter) {
+        patterns = Stream.of(messageRegexFilter.split("&&&"))
+            .filter(re -> re.trim()
+                .length() > 0)
+            .map(re -> Pattern.compile(re))
+            .collect(Collectors.toList());
+        this.converter = converter;
+    }
+
+    @Override
+    public String formatCommitMessage(String original) {
+
+        TreeSet<Pair<Integer, Integer>> regionsToSave = new TreeSet<>((Comparator<Pair<Integer, Integer>>) (o1, o2) -> o1.getLeft()
+            .compareTo(o2.getLeft()));
+
+        patterns.forEach(pattern -> {
+            Matcher m = pattern.matcher(original);
+            while (m.find()) {
+                if (m.group(1) != null) {
+                    MatchResult matchResult = m.toMatchResult();
+                    regionsToSave.add(new ImmutablePair<>(matchResult.start(1), matchResult.end(1)));
+                }
+            }
+        });
+
+
+        StringBuffer sb = new StringBuffer("");
+        regionsToSave.forEach(pair -> {
+                sb.append(original, pair.getLeft(), pair.getRight());
+                sb.append(" ");
+            }
+        );
+
+        String retStr = sb.toString()
+            .trim();
+
+        if (converter!=null){
+            retStr=converter.formatCommitMessage(retStr);
+        }
+        return retStr;
+    }
+}

--- a/src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java
@@ -45,6 +45,16 @@ public class GeneratorTest {
         generateReport(log, renderer);
     }
 
+
+    @Test
+    public void writePlainTextLogToFileWRegexFilter() throws Exception {
+        Log log = new SystemStreamLog();
+        RegexFilterMessageConverter converter = new RegexFilterMessageConverter("((Merge pull request #)\\d+)&&&((update)\\s+\\w+)",null);
+        ChangeLogRenderer renderer = new PlainTextRenderer(log, new File(TARGET_DIR), "changelog_w_regexfilter.txt", false,converter);
+        generateReport(log, renderer);
+    }
+
+
     @Test
     public void writePlainTextFullLogToFile() throws Exception {
         Log log = new SystemStreamLog();

--- a/src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/RegexFilterMessageConverterTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/RegexFilterMessageConverterTest.java
@@ -1,0 +1,46 @@
+package com.github.danielflower.mavenplugins.gitlog.renderers;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.junit.Test;
+
+public class RegexFilterMessageConverterTest {
+
+
+    @Test
+    public void testEmpty(){
+        RegexFilterMessageConverter converter=new RegexFilterMessageConverter("((SOF|SAP)-\\d+)", null);
+        assertThat(converter.formatCommitMessage("lkjlkj"),equalTo(""));
+    }
+
+    @Test
+    public void testReplace1(){
+        RegexFilterMessageConverter converter=new RegexFilterMessageConverter("((SOF|SAP)-\\d+)", null);
+        assertThat(converter.formatCommitMessage("hej hopp SOF-42 ugga bugga "),equalTo("SOF-42"));
+    }
+
+    @Test
+    public void testReplace12(){
+        RegexFilterMessageConverter converter=new RegexFilterMessageConverter("((SOF|SAP)-\\d+)", null);
+        assertThat(converter.formatCommitMessage("SAP-42"),equalTo("SAP-42"));
+    }
+
+
+    @Test
+    public void testReplace2(){
+        RegexFilterMessageConverter converter=new RegexFilterMessageConverter("((SOF|SAP)-\\d+)&&&(hejamora)", null);
+        assertThat(converter.formatCommitMessage("heja SAP-42 mora hejamora"),equalTo("SAP-42 hejamora"));
+    }
+
+    @Test
+    public void testReplaceWithConverter(){
+        JiraIssueLinkConverter c = new JiraIssueLinkConverter(new SystemStreamLog(),
+            "https://jira.atlassian.com/browse/CONF/");
+        RegexFilterMessageConverter converter=new RegexFilterMessageConverter("((SOF|SAP)-\\d+)&&&(hejamora)", c);
+        assertThat(converter.formatCommitMessage("heja SAP-42 mora hejamora"),equalTo("<a href=\"https://jira.atlassian.com/browse/SAP-42\">SAP-42</a> hejamora"));
+    }
+
+
+}


### PR DESCRIPTION
…ve everything in the commit message that doesn't match with the regex

Hi, I want to be able to tell downstream users what is currently running on our service. therefore I want to give them access to the changelog, containing only jiraissues-ids that they can check in an browser. 

I have added a possibility to remove everything from a commit message apart from whatever matches the given regex

see changed and added tests for an overview

Hope that you will find this good enough to be merged, 
/erik