### PR TITLE
Add jiraPattern option to support custom jira projects

### DIFF
--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/GenerateMojo.java
@@ -178,6 +178,15 @@ public class GenerateMojo extends AbstractMojo {
 	private String bugzillaPattern;
 
 	/**
+	 * Regexp pattern to extract the number from the message.
+	 * <p>
+	 * The default is: "[A-Z]+-[0-9]+".
+	 * Group 1 (the number) is used in links, so "?:" must be used any non relevant group,
+	 */
+	@Parameter(defaultValue = "[A-Z]+-[0-9]+")
+	private String jiraPattern;
+
+	/**
 	 * Used to set date format in log messages.
 	 */
 	@Parameter(defaultValue = "yyyy-MM-dd HH:mm:ss Z")
@@ -409,7 +418,7 @@ public class GenerateMojo extends AbstractMojo {
 			if (issueManagementUrl != null && issueManagementUrl.contains("://")) {
 				String system = ("" + issueManagementSystem).toLowerCase();
 				if (system.toLowerCase().contains("jira")) {
-					converter = new JiraIssueLinkConverter(getLog(), issueManagementUrl);
+					converter = new JiraIssueLinkConverter(getLog(), issueManagementUrl, jiraPattern);
 				} else if (system.toLowerCase().contains("github")) {
 					converter = new GitHubIssueLinkConverter(getLog(), issueManagementUrl);
 				} else if (system.toLowerCase().contains("bugzilla")) {

--- a/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/JiraIssueLinkConverter.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/gitlog/renderers/JiraIssueLinkConverter.java
@@ -11,13 +11,13 @@ public class JiraIssueLinkConverter implements MessageConverter {
 	private final Log log;
 	private final String urlPrefix;
 
-	public JiraIssueLinkConverter(Log log, String urlPrefix) {
+	public JiraIssueLinkConverter(Log log, String urlPrefix, String jiraPattern) {
 		this.log = log;
 		// strip off trailing slash
 		urlPrefix = urlPrefix.endsWith("/") ? urlPrefix.substring(0, urlPrefix.length() - 2) : urlPrefix;
 		// strip off jira project code
 		this.urlPrefix = urlPrefix.substring(0, urlPrefix.lastIndexOf("/") + 1);
-		this.pattern = Pattern.compile("[A-Z]+-[0-9]+");
+		this.pattern = Pattern.compile(jiraPattern);
 	}
 
 	@Override

--- a/src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/gitlog/GeneratorTest.java
@@ -14,6 +14,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.github.danielflower.mavenplugins.gitlog.renderers.JiraIssueLinkConverterTest.JIRA_PATTERN;
+
 // Not unit tests as such, but a way to manually observe the output during maven test phase
 public class GeneratorTest {
     private static final String THIS_PLUGIN_ISSUES = "https://github.com/danielflower/maven-gitlog-plugin/issues/";
@@ -101,7 +103,7 @@ public class GeneratorTest {
 	@Test
 	public void writeAsciidocLogToFileJiraAsTableView() throws Exception {
 		Log log = new SystemStreamLog();
-		JiraIssueLinkConverter messageConverter = new JiraIssueLinkConverter(log, THIS_PLUGIN_ISSUES);
+		JiraIssueLinkConverter messageConverter = new JiraIssueLinkConverter(log, THIS_PLUGIN_ISSUES, JIRA_PATTERN);
 		ChangeLogRenderer renderer = new AsciidocRenderer(log, new File(TARGET_DIR), "changelog-jira-asTableview.adoc", false, messageConverter, "==", true,"Date", "Commit");
 		generateReport(log, renderer);
 	}

--- a/src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/JiraIssueLinkConverterTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/gitlog/renderers/JiraIssueLinkConverterTest.java
@@ -7,7 +7,8 @@ import org.junit.Test;
 public class JiraIssueLinkConverterTest {
 
 	private static final String PREFIX = "https://jira.atlassian.com/browse/CONF";
-	private JiraIssueLinkConverter converter = new JiraIssueLinkConverter(new SystemStreamLog(), PREFIX);
+	public static final String JIRA_PATTERN = "[A-Z]+-[0-9]+";
+	private final JiraIssueLinkConverter converter = new JiraIssueLinkConverter(new SystemStreamLog(), PREFIX, JIRA_PATTERN);
 
 	@Test
 	public void emptyMessagesAreUnchanged() {
@@ -46,7 +47,7 @@ public class JiraIssueLinkConverterTest {
 	@Test
 	public void urlWithTrailingSlashHasItRemovedCorrectly() {
 		JiraIssueLinkConverter converter = new JiraIssueLinkConverter(new SystemStreamLog(),
-				"https://jira.atlassian.com/browse/CONF/");
+				"https://jira.atlassian.com/browse/CONF/", JIRA_PATTERN);
 		String actual = converter.formatCommitMessage("CONF-10 Some commit message");
 		assertEquals("<a href=\"https://jira.atlassian.com/browse/CONF-10\">CONF-10</a> Some commit message", actual);
 	}


### PR DESCRIPTION
Need this option to specify a pattern for extracting jira mumber for projects that do not respect the default pattern.

Example: my jira project is AB01CDE-123